### PR TITLE
docs: add IGP initialization task and reorganize Epic 3 workflow 

### DIFF
--- a/cardano/docs/tasks/epic-3-gas-payments/EPIC.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/EPIC.md
@@ -28,7 +28,7 @@ Per the official Hyperlane documentation, the IGP must support:
 | Gas oracles per destination | ✅ Implemented | `GasOracleConfig` per domain |
 | `GasPayment` event emission | ✅ Adapted | Redeemer serves as event on Cardano |
 | Post-dispatch hook integration | ❌ Missing | For automatic gas payment at dispatch |
-| Relayer gas payment indexing | ⬜ Pending | Task 3.1 |
+| Relayer gas payment indexing | ⬜ Pending | Task 3.2 |
 
 ## Current State
 
@@ -51,31 +51,45 @@ Per the official Hyperlane documentation, the IGP must support:
 
 | # | Task | Status | Depends On | Description |
 |---|------|--------|------------|-------------|
-| 3.1 | [RPC Endpoint](./task-3.1-rpc-endpoint.md) | ⬜ | - | Implement gas payment indexing and quote endpoint |
-| 3.2 | [CLI Commands](./task-3.2-cli-commands.md) | ⬜ | - | pay-for-gas, quote, claim, set-oracle, show |
-| 3.3 | [Relayer Integration](./task-3.3-relayer-integration.md) | ⬜ | 3.1 | Relayer queries and enforces gas payments |
-| 3.4 | [E2E Testing](./task-3.4-e2e-testing.md) | ⬜ | 3.1-3.3 | Test full payment flow |
-| 3.5 | [Post-Dispatch Hook](./task-3.5-post-dispatch-hook.md) | ⬜ | 3.1-3.2 | Automatic gas payment at dispatch time |
-| 3.6 | [Contract Enhancements](./task-3.6-contract-enhancements.md) | ⬜ | - | Refund handling, per-destination defaults |
+| 3.0 | [Init IGP](./task-3.0-init-igp.md) | ⬜ | - | **PREREQUISITE**: Initialize IGP contract on testnet |
+| 3.1 | [CLI Commands](./task-3.1-cli-commands.md) | ⬜ | 3.0 | pay-for-gas, quote, claim, set-oracle, show |
+| 3.2 | [RPC Endpoint](./task-3.2-rpc-endpoint.md) | ⬜ | 3.0 | Implement gas payment indexing and quote endpoint |
+| 3.3 | [Contract Enhancements](./task-3.3-contract-enhancements.md) | ⬜ | - | Refund handling, per-destination defaults |
+| 3.4 | [Relayer Integration](./task-3.4-relayer-integration.md) | ⬜ | 3.2 | Relayer queries and enforces gas payments |
+| 3.5 | [Post-Dispatch Hook](./task-3.5-post-dispatch-hook.md) | ⬜ | 3.1, 3.2, 3.3 | Automatic gas payment at dispatch time |
+| 3.6 | [E2E Testing](./task-3.6-e2e-testing.md) | ⬜ | 3.1-3.5 | Test full payment flow |
 
 ## Task Dependency Graph
 
 ```
-Task 3.6 (Contract)     Task 3.1 (RPC)      Task 3.2 (CLI)
-    │                       │                    │
-    └───────────┬───────────┘                    │
-                │                                │
-                ▼                                │
-    Task 3.3 (Relayer Integration)               │
-                │                                │
-                ├────────────────────────────────┘
-                │
-                ▼
-    Task 3.5 (Post-Dispatch Hook)
-                │
-                ▼
-        Task 3.4 (E2E Testing)
+                    Task 3.0 (Init IGP)
+                           │
+           ┌───────────────┼───────────────┐
+           │               │               │
+           ▼               ▼               ▼
+    Task 3.3         Task 3.1        Task 3.2
+    (Contract)       (CLI)           (RPC)
+           │               │               │
+           └───────┬───────┴───────┬───────┘
+                   │               │
+                   ▼               ▼
+           Task 3.5          Task 3.4
+           (Post-Dispatch)   (Relayer)
+                   │               │
+                   └───────┬───────┘
+                           │
+                           ▼
+                   Task 3.6 (E2E Testing)
 ```
+
+**Implementation order (matches task numbers):**
+1. **Task 3.0** - Init IGP (prerequisite for testing all others)
+2. **Task 3.1** - CLI Commands (enables manual testing)
+3. **Task 3.2** - RPC Endpoint (verify with payments from CLI)
+4. **Task 3.3** - Contract Enhancements (can be done in parallel with 3.1/3.2)
+5. **Task 3.4** - Relayer Integration
+6. **Task 3.5** - Post-Dispatch Hook
+7. **Task 3.6** - E2E Testing
 
 ## Technical Architecture
 

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.0-init-igp.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.0-init-igp.md
@@ -1,0 +1,263 @@
+[← Epic 3: Gas Payments](./EPIC.md) | [Epics Overview](../README.md)
+
+# Task 3.0: Initialize IGP Contract
+**Status:** ⬜ Not Started
+**Complexity:** Low
+**Depends On:** None (PREREQUISITE for all other Epic 3 tasks)
+
+## Objective
+
+Add `init igp` CLI command to initialize the Interchain Gas Paymaster contract on Cardano. This is a prerequisite for all other Epic 3 tasks since they require an initialized IGP to test against.
+
+## Background
+
+The IGP contract exists (`cardano/contracts/validators/igp.ak`) but is not initialized on testnet. Like other Hyperlane contracts (Mailbox, ISM, Registry), it requires:
+- A one-shot state NFT for UTXO identification
+- An initial datum with configuration
+- Registration in `deployment_info.json`
+
+Without initialization, we cannot:
+- Test CLI commands (Task 3.2)
+- Verify the Rust indexer (Task 3.1)
+- Run relayer integration tests (Task 3.3)
+- Perform E2E testing (Task 3.4)
+
+## IGP Datum Structure
+
+From `cardano/contracts/lib/types.ak`:
+
+```aiken
+pub type IgpDatum {
+  owner: VerificationKeyHash,           // Who can configure oracles
+  beneficiary: ByteArray,               // Who receives claimed fees
+  gas_oracles: List<(Domain, GasOracleConfig)>,  // Price config per destination
+  default_gas_limit: Int,               // Default gas if not specified
+}
+
+pub type GasOracleConfig {
+  gas_price: Int,                       // Destination chain gas price
+  token_exchange_rate: Int,             // ADA to destination token rate
+}
+```
+
+## Requirements
+
+### 1. Add `build_igp_datum()` to CBOR Utils
+
+**File:** `cardano/cli/src/utils/cbor.rs`
+
+```rust
+/// Build IGP datum CBOR
+/// Structure: Constr 0 [owner, beneficiary, gas_oracles, default_gas_limit]
+pub fn build_igp_datum(
+    owner_pkh: &str,                      // 28 bytes hex (verification key hash)
+    beneficiary: &str,                    // 28 bytes hex (verification key hash)
+    gas_oracles: &[(u32, u64, u64)],      // (domain, gas_price, exchange_rate)
+    default_gas_limit: u64,
+) -> Result<Vec<u8>>
+```
+
+CBOR structure:
+```
+Constr 0 [
+  owner: ByteArray (28 bytes),
+  beneficiary: ByteArray (28 bytes),
+  gas_oracles: List<(Int, Constr 0 [Int, Int])>,
+  default_gas_limit: Int
+]
+```
+
+### 2. Add `Igp` Variant to `InitCommands`
+
+**File:** `cardano/cli/src/commands/init.rs`
+
+```rust
+/// Initialize the IGP (Interchain Gas Paymaster) contract
+Igp {
+    /// Beneficiary address for claimed fees (defaults to signer's pkh)
+    #[arg(long)]
+    beneficiary: Option<String>,
+
+    /// Default gas limit for messages
+    #[arg(long, default_value = "200000")]
+    default_gas_limit: u64,
+
+    /// Gas oracle config: "domain:gas_price:exchange_rate" (repeatable)
+    #[arg(long = "oracle")]
+    oracles: Vec<String>,
+
+    /// UTXO to use for minting state NFT (tx_hash#index)
+    #[arg(long)]
+    utxo: Option<String>,
+
+    /// Dry run - show what would be done without submitting
+    #[arg(long)]
+    dry_run: bool,
+},
+```
+
+### 3. Implement `init_igp()` Function
+
+**Flow:**
+
+```
+1. Load signing key → derive owner_pkh
+2. Determine beneficiary:
+   - If --beneficiary provided: parse and use
+   - Else: use owner_pkh (signer receives fees)
+3. Parse --oracle flags into (domain, gas_price, exchange_rate) tuples
+4. Get UTXOs from wallet, find suitable one (>= 10 ADA, no assets)
+5. Encode output reference for one-shot NFT parameter
+6. Apply state_nft parameter → get NFT policy ID
+7. Get IGP script address from deployment_info.json
+8. Build IGP datum with:
+   - owner: owner_pkh
+   - beneficiary: beneficiary_pkh
+   - gas_oracles: parsed from --oracle flags (empty list if none)
+   - default_gas_limit: from --default-gas-limit
+9. Build transaction:
+   - Input: selected UTXO
+   - Mint: state NFT with policy from step 6
+   - Output: IGP address + 5 ADA + state NFT + datum
+   - Collateral: separate UTXO
+10. Sign with Cardano signing key
+11. Submit to network
+12. Update deployment_info.json:
+    - igp.stateNftPolicy = NFT policy ID
+    - igp.stateNft = { policyId, assetName, seedUtxo }
+    - igp.stateUtxo = "tx_hash#0"
+    - igp.initTxHash = tx_hash
+    - igp.initialized = true
+```
+
+### 4. Wire Up in Execute Match
+
+```rust
+InitCommands::Igp { beneficiary, default_gas_limit, oracles, utxo, dry_run } =>
+    init_igp(ctx, beneficiary, default_gas_limit, oracles, utxo, dry_run).await,
+```
+
+## CLI Interface
+
+```bash
+# Basic initialization (owner = beneficiary = signer, no oracles)
+hyperlane-cardano init igp
+
+# With default gas limit
+hyperlane-cardano init igp --default-gas-limit 200000
+
+# With Fuji oracle configured
+hyperlane-cardano init igp \
+  --default-gas-limit 200000 \
+  --oracle "43113:25000000000:1000000"
+
+# With multiple oracles
+hyperlane-cardano init igp \
+  --oracle "43113:25000000000:1000000" \
+  --oracle "11155111:30000000000:1200000"
+
+# With custom beneficiary (different from owner)
+hyperlane-cardano init igp \
+  --beneficiary addr_test1qz... \
+  --default-gas-limit 200000
+
+# Dry run to preview
+hyperlane-cardano init igp --dry-run
+```
+
+### Oracle Format
+
+`--oracle "domain:gas_price:exchange_rate"`
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| domain | Destination domain ID | 43113 (Fuji) |
+| gas_price | Gas price in destination native units | 25000000000 (25 gwei) |
+| exchange_rate | ADA to destination token rate (scaled) | 1000000 |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `cardano/cli/src/commands/init.rs` | Add `Igp` command variant, `init_igp()` function |
+| `cardano/cli/src/utils/cbor.rs` | Add `build_igp_datum()` function |
+| `cardano/deployments/preview/deployment_info.json` | Auto-updated after init |
+
+## Expected Output
+
+```
+Initializing IGP contract...
+  Owner: a1b2c3d4e5f6...
+  Beneficiary: a1b2c3d4e5f6...
+  Default Gas Limit: 200,000
+  Gas Oracles: 1 configured
+    - Domain 43113: gas_price=25000000000, exchange_rate=1000000
+
+Applying state_nft parameter...
+  Input UTXO: abc123...#0
+  State NFT Policy ID: 7f8e9d0c1a2b...
+
+Building transaction...
+  IGP Address: addr_test1wpqlvpjt4xvfmtuwltkq0yekqs342tfdevh3dxgj2j3fqtg5pzvu0
+  Output: 5 ADA + state NFT + datum
+  TX Hash: def456...
+
+Signing transaction...
+  Signed TX size: 892 bytes
+
+Submitting transaction...
+✓ Transaction submitted!
+  TX Hash: def456789abc...
+  Explorer: https://preview.cardanoscan.io/transaction/def456789abc...
+
+✓ Deployment info updated
+  IGP State NFT Policy: 7f8e9d0c1a2b...
+  IGP State UTXO: def456789abc...#0
+  IGP Initialized: true
+```
+
+## Testing
+
+### Manual Testing on Preview
+
+1. Ensure wallet has >= 15 ADA (10 for init, 5 for collateral)
+2. Run dry-run first:
+   ```bash
+   hyperlane-cardano init igp --dry-run
+   ```
+3. If dry-run looks good, run actual init:
+   ```bash
+   hyperlane-cardano init igp --default-gas-limit 200000
+   ```
+4. Verify on explorer that UTXO exists at IGP address
+5. Verify `deployment_info.json` updated correctly
+6. Run `hyperlane-cardano init status` to confirm
+
+### Verification Checklist
+
+- [ ] Transaction submitted successfully
+- [ ] UTXO visible on CardanoScan at IGP address
+- [ ] State NFT present in UTXO
+- [ ] Datum correctly formed (can decode with Blockfrost)
+- [ ] `deployment_info.json` has:
+  - `igp.initialized = true`
+  - `igp.stateNftPolicy` set
+  - `igp.stateUtxo` set
+- [ ] `init status` shows IGP as initialized
+
+## Definition of Done
+
+- [ ] `build_igp_datum()` implemented and tested
+- [ ] `init igp` command added to CLI
+- [ ] Dry-run mode works correctly
+- [ ] Successfully initialized on Preview testnet
+- [ ] `deployment_info.json` updated correctly
+- [ ] Documentation updated
+
+## Acceptance Criteria
+
+1. `init igp` command creates valid IGP UTXO on-chain
+2. State NFT minted and included in output
+3. Datum matches expected structure
+4. Gas oracles correctly encoded
+5. Deployment info persisted for other tasks to use

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.0-init-igp.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.0-init-igp.md
@@ -220,29 +220,45 @@ Submitting transaction...
 
 ### Manual Testing on Preview
 
-1. Ensure wallet has >= 15 ADA (10 for init, 5 for collateral)
-2. Run dry-run first:
+1. Ensure wallet has >= 30 ADA (12 for reference script, 10 for init, 5 for collateral, buffer for fees)
+
+2. Deploy IGP reference script (required before init):
+   ```bash
+   hyperlane-cardano deploy reference-script --script igp --dry-run
+   # If dry-run looks good:
+   hyperlane-cardano deploy reference-script --script igp
+   ```
+   This creates a UTXO containing the IGP validator script that can be referenced by future transactions, saving transaction fees.
+
+3. Run init dry-run:
    ```bash
    hyperlane-cardano init igp --dry-run
    ```
-3. If dry-run looks good, run actual init:
+
+4. If dry-run looks good, run actual init:
    ```bash
    hyperlane-cardano init igp --default-gas-limit 200000
    ```
-4. Verify on explorer that UTXO exists at IGP address
-5. Verify `deployment_info.json` updated correctly
-6. Run `hyperlane-cardano init status` to confirm
+
+5. Verify on explorer that UTXO exists at IGP address
+
+6. Verify `deployment_info.json` updated correctly
+
+7. Run `hyperlane-cardano init status` to confirm
 
 ### Verification Checklist
 
-- [ ] Transaction submitted successfully
-- [ ] UTXO visible on CardanoScan at IGP address
+- [ ] Reference script deployed successfully
+- [ ] `deployment_info.json` has `igp.referenceScriptUtxo` set
+- [ ] Init transaction submitted successfully
+- [ ] State UTXO visible on CardanoScan at IGP address
 - [ ] State NFT present in UTXO
 - [ ] Datum correctly formed (can decode with Blockfrost)
 - [ ] `deployment_info.json` has:
   - `igp.initialized = true`
   - `igp.stateNftPolicy` set
   - `igp.stateUtxo` set
+  - `igp.referenceScriptUtxo` set
 - [ ] `init status` shows IGP as initialized
 
 ## Definition of Done

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.1-cli-commands.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.1-cli-commands.md
@@ -1,9 +1,9 @@
 [← Epic 3: Gas Payments](./EPIC.md) | [Epics Overview](../README.md)
 
-# Task 3.2: IGP CLI Commands
+# Task 3.1: IGP CLI Commands
 **Status:** ⬜ Not Started
 **Complexity:** Medium
-**Depends On:** None
+**Depends On:** [Task 3.0](./task-3.0-init-igp.md)
 
 ## Objective
 

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.2-rpc-endpoint.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.2-rpc-endpoint.md
@@ -1,9 +1,9 @@
 [← Epic 3: Gas Payments](./EPIC.md) | [Epics Overview](../README.md)
 
-# Task 3.1: RPC Endpoint for Gas Payments
+# Task 3.2: RPC Endpoint for Gas Payments
 **Status:** ⬜ Not Started
 **Complexity:** Medium
-**Depends On:** None
+**Depends On:** [Task 3.0](./task-3.0-init-igp.md)
 
 ## Objective
 

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.3-contract-enhancements.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.3-contract-enhancements.md
@@ -1,6 +1,6 @@
 [← Epic 3: Gas Payments](./EPIC.md) | [Epics Overview](../README.md)
 
-# Task 3.6: IGP Contract Enhancements
+# Task 3.3: IGP Contract Enhancements
 **Status:** ⬜ Not Started
 **Complexity:** Medium
 **Depends On:** None (but should be done early as it affects other tasks)

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.4-relayer-integration.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.4-relayer-integration.md
@@ -1,9 +1,9 @@
 [← Epic 3: Gas Payments](./EPIC.md) | [Epics Overview](../README.md)
 
-# Task 3.3: Relayer Integration
+# Task 3.4: Relayer Integration
 **Status:** ⬜ Not Started
 **Complexity:** Medium
-**Depends On:** [Task 3.1](./task-3.1-rpc-endpoint.md)
+**Depends On:** [Task 3.2](./task-3.2-rpc-endpoint.md)
 
 ## Objective
 

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.5-post-dispatch-hook.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.5-post-dispatch-hook.md
@@ -3,7 +3,7 @@
 # Task 3.5: Post-Dispatch Hook Integration
 **Status:** ⬜ Not Started
 **Complexity:** High
-**Depends On:** [Task 3.1](./task-3.1-rpc-endpoint.md), [Task 3.2](./task-3.2-cli-commands.md), [Task 3.6](./task-3.6-contract-enhancements.md)
+**Depends On:** [Task 3.1](./task-3.1-cli-commands.md), [Task 3.2](./task-3.2-rpc-endpoint.md), [Task 3.3](./task-3.3-contract-enhancements.md)
 
 ## Objective
 

--- a/cardano/docs/tasks/epic-3-gas-payments/task-3.6-e2e-testing.md
+++ b/cardano/docs/tasks/epic-3-gas-payments/task-3.6-e2e-testing.md
@@ -1,9 +1,9 @@
 [← Epic 3: Gas Payments](./EPIC.md) | [Epics Overview](../README.md)
 
-# Task 3.4: IGP End-to-End Testing
+# Task 3.6: IGP End-to-End Testing
 **Status:** ⬜ Not Started
 **Complexity:** Medium
-**Depends On:** Tasks 3.1-3.3, 3.5, 3.6
+**Depends On:** Tasks 3.1-3.5
 
 ## Objective
 


### PR DESCRIPTION
### Description

Added Task 3.0 (Init IGP) as prerequisite for Epic 3 and reorganized task numbers to match recommended implementation order. 

## Changes                                                                                     
                                                                                              
  - Added task-3.0-init-igp.md documenting IGP contract initialization                        
  - Renumbered tasks to follow implementation order:                                          
    - 3.0 Init IGP (new)                                                                      
    - 3.1 CLI Commands (was 3.2)                                                              
    - 3.2 RPC Endpoint (was 3.1)                                                              
    - 3.3 Contract Enhancements (was 3.6)                                                     
    - 3.4 Relayer Integration (was 3.3)                                                       
    - 3.5 Post-Dispatch Hook                                                                  
    - 3.6 E2E Testing (was 3.4)                                                               
  - Updated EPIC.md with new task table and dependency graph                                  
                                                                                              
  ## Rationale                                                                                   
                                                                                              
  IGP initialization must happen first since all other tasks (CLI commands, RPC endpoint, testing) require a deployed IGP contract to work against. Task numbering now reflects the actual implementation sequence.