### PR TITLE
fix(cardano): prevent consumption of ref script UTXOs

### DIFF
--- a/cardano/cli/src/commands/deferred.rs
+++ b/cardano/cli/src/commands/deferred.rs
@@ -517,7 +517,7 @@ async fn process_message(
     println!("  Messages Stored: {}", messages_stored);
     println!("  Messages Processed: {}", messages_processed);
 
-    // 3. Find fee UTXOs
+    // 3. Find fee UTXOs (must not have reference scripts)
     let fee_utxos = client.get_utxos(&payer_address).await?;
     if fee_utxos.is_empty() {
         return Err(anyhow!("No UTXOs found at payer address for fees"));
@@ -525,8 +525,8 @@ async fn process_message(
 
     let fee_utxo = fee_utxos
         .iter()
-        .find(|u| u.assets.is_empty() && u.lovelace >= 5_000_000)
-        .ok_or_else(|| anyhow!("No suitable fee UTXO found (need >= 5 ADA)"))?;
+        .find(|u| u.assets.is_empty() && u.lovelace >= 5_000_000 && u.reference_script.is_none())
+        .ok_or_else(|| anyhow!("No suitable fee UTXO found (need >= 5 ADA without tokens or reference scripts)"))?;
 
     println!("\n{}", "Fee UTXO:".green());
     println!("  {}#{}", fee_utxo.tx_hash, fee_utxo.output_index);

--- a/cardano/cli/src/commands/deploy.rs
+++ b/cardano/cli/src/commands/deploy.rs
@@ -421,11 +421,11 @@ async fn deploy_reference_script_internal(
         .collect();
     println!("  Found {} UTXOs at wallet (excluding {} spent)", utxos.len(), exclude_utxos.len());
 
-    // Find suitable UTXOs
+    // Find suitable UTXOs (must not have reference scripts)
     let input_utxo = utxos
         .iter()
-        .find(|u| u.lovelace >= lovelace + 5_000_000 && u.assets.is_empty())
-        .ok_or_else(|| anyhow!("No suitable UTXO found (need >= {} ADA without assets)", (lovelace + 5_000_000) / 1_000_000))?;
+        .find(|u| u.lovelace >= lovelace + 5_000_000 && u.assets.is_empty() && u.reference_script.is_none())
+        .ok_or_else(|| anyhow!("No suitable UTXO found (need >= {} ADA without assets or reference scripts)", (lovelace + 5_000_000) / 1_000_000))?;
 
     println!("  Input UTXO: {}#{}", input_utxo.tx_hash, input_utxo.output_index);
 

--- a/cardano/cli/src/commands/init.rs
+++ b/cardano/cli/src/commands/init.rs
@@ -324,22 +324,23 @@ async fn init_mailbox_internal(
         None => {
             utxos
                 .iter()
-                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty())
+                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty() && u.reference_script.is_none())
                 .cloned()
-                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets)"))?
+                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets or reference scripts)"))?
         }
     };
 
-    // Find collateral UTXO (must be different from input)
+    // Find collateral UTXO (must be different from input, must not have reference script)
     let collateral_utxo = utxos
         .iter()
         .find(|u| {
             u.lovelace >= 5_000_000
                 && u.assets.is_empty()
+                && u.reference_script.is_none()
                 && !(u.tx_hash == input_utxo.tx_hash && u.output_index == input_utxo.output_index)
         })
         .cloned()
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (need a second UTXO with >= 5 ADA)"))?;
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (need a second UTXO with >= 5 ADA without reference scripts)"))?;
 
     println!("  Input UTXO: {}#{}", input_utxo.tx_hash, input_utxo.output_index);
     println!("  Collateral: {}#{}", collateral_utxo.tx_hash, collateral_utxo.output_index);
@@ -547,22 +548,23 @@ async fn init_ism_internal(
         None => {
             utxos
                 .iter()
-                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty())
+                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty() && u.reference_script.is_none())
                 .cloned()
-                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets)"))?
+                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets or reference scripts)"))?
         }
     };
 
-    // Find collateral UTXO
+    // Find collateral UTXO (must not have reference script)
     let collateral_utxo = utxos
         .iter()
         .find(|u| {
             u.lovelace >= 5_000_000
                 && u.assets.is_empty()
+                && u.reference_script.is_none()
                 && !(u.tx_hash == input_utxo.tx_hash && u.output_index == input_utxo.output_index)
         })
         .cloned()
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO found"))?;
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (without reference scripts)"))?;
 
     println!("  Input UTXO: {}#{}", input_utxo.tx_hash, input_utxo.output_index);
     println!("  Collateral: {}#{}", collateral_utxo.tx_hash, collateral_utxo.output_index);
@@ -730,22 +732,23 @@ async fn init_registry_internal(
         None => {
             utxos
                 .iter()
-                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty())
+                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty() && u.reference_script.is_none())
                 .cloned()
-                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets)"))?
+                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets or reference scripts)"))?
         }
     };
 
-    // Find collateral UTXO
+    // Find collateral UTXO (must not have reference script)
     let collateral_utxo = utxos
         .iter()
         .find(|u| {
             u.lovelace >= 5_000_000
                 && u.assets.is_empty()
+                && u.reference_script.is_none()
                 && !(u.tx_hash == input_utxo.tx_hash && u.output_index == input_utxo.output_index)
         })
         .cloned()
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO found"))?;
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (without reference scripts)"))?;
 
     println!("  Input UTXO: {}#{}", input_utxo.tx_hash, input_utxo.output_index);
     println!("  Collateral: {}#{}", collateral_utxo.tx_hash, collateral_utxo.output_index);
@@ -916,22 +919,23 @@ async fn init_igp(
         None => {
             utxos
                 .iter()
-                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty())
+                .find(|u| u.lovelace >= 10_000_000 && u.assets.is_empty() && u.reference_script.is_none())
                 .cloned()
-                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets)"))?
+                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= 10 ADA without assets or reference scripts)"))?
         }
     };
 
-    // Find collateral UTXO
+    // Find collateral UTXO (must not have reference script)
     let collateral_utxo = utxos
         .iter()
         .find(|u| {
             u.lovelace >= 5_000_000
                 && u.assets.is_empty()
+                && u.reference_script.is_none()
                 && !(u.tx_hash == input_utxo.tx_hash && u.output_index == input_utxo.output_index)
         })
         .cloned()
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (need a second UTXO with >= 5 ADA)"))?;
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (need a second UTXO with >= 5 ADA without reference scripts)"))?;
 
     println!("  Input UTXO: {}#{}", input_utxo.tx_hash, input_utxo.output_index);
     println!("  Collateral: {}#{}", collateral_utxo.tx_hash, collateral_utxo.output_index);
@@ -1152,22 +1156,23 @@ async fn init_recipient(
         None => {
             utxos
                 .iter()
-                .find(|u| u.lovelace >= min_required && u.assets.is_empty())
+                .find(|u| u.lovelace >= min_required && u.assets.is_empty() && u.reference_script.is_none())
                 .cloned()
-                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= {} ADA without assets)", min_required / 1_000_000))?
+                .ok_or_else(|| anyhow!("No suitable UTXO found (need >= {} ADA without assets or reference scripts)", min_required / 1_000_000))?
         }
     };
 
-    // Find collateral UTXO
+    // Find collateral UTXO (must not have reference script)
     let collateral_utxo = utxos
         .iter()
         .find(|u| {
             u.lovelace >= 5_000_000
                 && u.assets.is_empty()
+                && u.reference_script.is_none()
                 && !(u.tx_hash == input_utxo.tx_hash && u.output_index == input_utxo.output_index)
         })
         .cloned()
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO found"))?;
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO found (without reference scripts)"))?;
 
     println!("  Input UTXO: {}#{} ({} ADA)", input_utxo.tx_hash, input_utxo.output_index, input_utxo.lovelace / 1_000_000);
     println!("  Collateral: {}#{}", collateral_utxo.tx_hash, collateral_utxo.output_index);

--- a/cardano/cli/src/commands/ism.rs
+++ b/cardano/cli/src/commands/ism.rs
@@ -299,18 +299,19 @@ async fn set_validators(
         return Err(anyhow!("No UTXOs found for payer address"));
     }
 
-    // Find collateral UTXO (pure ADA, no tokens)
+    // Find collateral UTXO (pure ADA, no tokens, no reference script)
     let collateral_utxo = payer_utxos
         .iter()
-        .find(|u| u.lovelace >= 5_000_000 && u.assets.is_empty())
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO (need 5+ ADA without tokens)"))?;
+        .find(|u| u.lovelace >= 5_000_000 && u.assets.is_empty() && u.reference_script.is_none())
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO (need 5+ ADA without tokens or reference scripts)"))?;
 
-    // Find fee UTXO (pure ADA, no tokens, different from collateral if possible)
+    // Find fee UTXO (pure ADA, no tokens, no reference script, different from collateral if possible)
     let fee_utxo = payer_utxos
         .iter()
         .find(|u| {
             u.lovelace >= 10_000_000 &&
             u.assets.is_empty() &&
+            u.reference_script.is_none() &&
             (u.tx_hash != collateral_utxo.tx_hash || u.output_index != collateral_utxo.output_index)
         })
         .or_else(|| {
@@ -318,6 +319,7 @@ async fn set_validators(
             payer_utxos.iter().find(|u| {
                 u.lovelace >= 5_000_000 &&
                 u.assets.is_empty() &&
+                u.reference_script.is_none() &&
                 (u.tx_hash != collateral_utxo.tx_hash || u.output_index != collateral_utxo.output_index)
             })
         })
@@ -562,24 +564,26 @@ async fn set_threshold(
         return Err(anyhow!("No UTXOs found for payer address"));
     }
 
-    // Find collateral UTXO (pure ADA, no tokens)
+    // Find collateral UTXO (pure ADA, no tokens, no reference script)
     let collateral_utxo = payer_utxos
         .iter()
-        .find(|u| u.lovelace >= 5_000_000 && u.assets.is_empty())
-        .ok_or_else(|| anyhow!("No suitable collateral UTXO (need 5+ ADA without tokens)"))?;
+        .find(|u| u.lovelace >= 5_000_000 && u.assets.is_empty() && u.reference_script.is_none())
+        .ok_or_else(|| anyhow!("No suitable collateral UTXO (need 5+ ADA without tokens or reference scripts)"))?;
 
-    // Find fee UTXO (pure ADA, no tokens, different from collateral if possible)
+    // Find fee UTXO (pure ADA, no tokens, no reference script, different from collateral if possible)
     let fee_utxo = payer_utxos
         .iter()
         .find(|u| {
             u.lovelace >= 10_000_000 &&
             u.assets.is_empty() &&
+            u.reference_script.is_none() &&
             (u.tx_hash != collateral_utxo.tx_hash || u.output_index != collateral_utxo.output_index)
         })
         .or_else(|| {
             payer_utxos.iter().find(|u| {
                 u.lovelace >= 5_000_000 &&
                 u.assets.is_empty() &&
+                u.reference_script.is_none() &&
                 (u.tx_hash != collateral_utxo.tx_hash || u.output_index != collateral_utxo.output_index)
             })
         })

--- a/cardano/cli/src/commands/tx.rs
+++ b/cardano/cli/src/commands/tx.rs
@@ -297,12 +297,12 @@ async fn build_payment(
     let api_key = ctx.require_api_key()?;
     let client = BlockfrostClient::new(ctx.blockfrost_url(), api_key);
 
-    // Find suitable UTXO
+    // Find suitable UTXO (must not have reference script)
     let utxos = client.get_utxos(&from).await?;
     let suitable = utxos
         .iter()
-        .find(|u| u.lovelace >= amount + 2_000_000 && u.assets.is_empty())
-        .ok_or_else(|| anyhow!("No suitable UTXO found (need >= {} lovelace)", amount + 2_000_000))?;
+        .find(|u| u.lovelace >= amount + 2_000_000 && u.assets.is_empty() && u.reference_script.is_none())
+        .ok_or_else(|| anyhow!("No suitable UTXO found (need >= {} lovelace without assets or reference scripts)", amount + 2_000_000))?;
 
     println!("  Input UTXO: {}#{}", suitable.tx_hash, suitable.output_index);
 


### PR DESCRIPTION
Our CLI would often pick and consume UTXOs that contained reference scripts associated with our hyperlane contracts. This patch adds checks to prevent that from happening.