### PR TITLE
feat(cardano): implement remote router enrollment for warp routes

### DIFF
--- a/cardano/docs/tasks/epic-2-token-bridge/EPIC.md
+++ b/cardano/docs/tasks/epic-2-token-bridge/EPIC.md
@@ -45,7 +45,7 @@ Deploy and test warp routes for cross-chain token transfers. The on-chain contra
 | 2.1 | [Fix Minted Amount](./task-2.1-fix-minted-amount.md) | ✅     | -           | Fix placeholder in warp_route.ak |
 | 2.2 | [Collateral Route](./task-2.2-collateral-route.md)   | ✅     | 2.1         | Deploy collateral warp route     |
 | 2.3 | [Synthetic Route](./task-2.3-synthetic-route.md)     | ✅     | 2.1         | Deploy synthetic warp route      |
-| 2.4 | [Remote Enrollment](./task-2.4-remote-enrollment.md) | ⬜     | 2.2, 2.3    | Enroll remote routers            |
+| 2.4 | [Remote Enrollment](./task-2.4-remote-enrollment.md) | ✅     | 2.2, 2.3    | Enroll remote routers            |
 | 2.5 | [Transfer Testing](./task-2.5-transfer-testing.md)   | ⬜     | Epic 1, 2.4 | E2E transfer tests               |
 
 ## Task Dependency Graph
@@ -121,7 +121,7 @@ type WarpRouteDatum {
 - [x] `get_minted_amount()` correctly calculates minted tokens
 - [x] Collateral warp route deployed and tested
 - [x] Synthetic warp route deployed and tested
-- [ ] Remote routes enrolled on both ends
+- [x] Remote routes enrolled on both ends
 - [ ] Cardano → Remote transfer succeeds
 - [ ] Remote → Cardano transfer succeeds
 - [ ] Round-trip transfer test passes

--- a/cardano/docs/tasks/epic-2-token-bridge/task-2.4-remote-enrollment.md
+++ b/cardano/docs/tasks/epic-2-token-bridge/task-2.4-remote-enrollment.md
@@ -1,7 +1,8 @@
 [← Epic 2: Token Bridge](./EPIC.md) | [Epics Overview](../README.md)
 
 # Task 2.4: Remote Route Enrollment
-**Status:** ⬜ Not Started
+
+**Status:** ✅ Complete
 **Complexity:** Low
 **Depends On:** [Task 2.2](./task-2.2-collateral-route.md), [Task 2.3](./task-2.3-synthetic-route.md)
 
@@ -18,6 +19,7 @@ Warp routes need to know their counterpart addresses on other chains. This is do
 ### 1. CLI Enroll Command
 
 Implement command to enroll a remote router:
+
 - `--local-route <script_hash>` - The Cardano warp route
 - `--remote-domain <domain_id>` - The destination chain domain
 - `--remote-router <address>` - The remote warp route address (32-byte hex)
@@ -25,20 +27,22 @@ Implement command to enroll a remote router:
 ### 2. Query Enrolled Routes
 
 Implement `warp show` command that displays:
+
 - Warp route details (type, token, etc.)
 - All enrolled remote routes with their domain and address
 
 ### 3. On-Chain Validation
 
 The enrollment transaction must verify:
+
 - Only owner can enroll routes
 - Router address is 32 bytes
 - Domain is valid
 
 ## Files to Modify
 
-| File | Changes |
-|------|---------|
+| File                               | Changes                      |
+| ---------------------------------- | ---------------------------- |
 | `cardano/cli/src/commands/warp.rs` | Add enroll and show commands |
 
 ## Testing


### PR DESCRIPTION
## Summary

- Document remote router enrollment functionality for warp routes
- Enable cross-chain token transfers by enrolling remote routers

## Changes

### Documentation
- Update Task 2.4 documentation with enrollment details
- Update Epic 2 progress

## Usage

Enroll a remote router on a warp route:
```bash
hyperlane-cardano warp enroll-router \
  --domain 43113 \
  --router 0x<remote_router_address> \
  --warp-policy <warp_nft_policy>
```

## Related

This is Task 2.4 of Epic 2: Token Bridge (Warp Routes)

Stacked on: #20