### PR TITLE
fix(cardano): message chain of trust

### DIFF
--- a/cardano/testnet-keys/recipient/payment.addr
+++ b/cardano/testnet-keys/recipient/payment.addr
@@ -1,0 +1,1 @@
+addr_test1vp4s2hc5ttr0syyj66x058wsh7e9wcq4vfq2l7fxr3qdqsqm5cdfx

--- a/cardano/testnet-keys/recipient/payment.skey
+++ b/cardano/testnet-keys/recipient/payment.skey
@@ -1,0 +1,5 @@
+{
+    "type": "PaymentSigningKeyShelley_ed25519",
+    "description": "Payment Signing Key",
+    "cborHex": "5820db8d0b992962036257faf23a195bdb868be1292a3c0d4e4a181c7e4f96ede80a"
+}

--- a/cardano/testnet-keys/recipient/payment.vkey
+++ b/cardano/testnet-keys/recipient/payment.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "PaymentVerificationKeyShelley_ed25519",
+    "description": "Payment Verification Key",
+    "cborHex": "58204d5f1b96cbd766189ec57cef7392557b72136b24f6f66fe31e8fcf744b9dd4b5"
+}


### PR DESCRIPTION
On Cardano, scripts in the same transaction receive data via separate redeemers. An attacker could provide a legitimate message to the mailbox but different data (e.g., higher amount) to the recipient.

Close this gap with two measures:

1. ReceiveTransfer now carries the full Message + message_id. The warp route verifies keccak256(encode_message(message)) == message_id, ensuring internal consistency of redeemer data.

2. All recipients (warp route, generic, deferred) now take a processed_messages_nft_policy parameter and verify that tx.mint contains the NFT for their message_id. Since only the mailbox can trigger this mint (after ISM validation), this cryptographically binds the recipient's message_id to what the mailbox validated.