### PR TITLE
feat(midnight): destination-side Mailbox via submitter subprocess (#20)

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6132,6 +6132,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.63",
  "tokio",
  "tracing",

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6127,6 +6127,7 @@ name = "hyperlane-midnight"
 version = "2.2.0"
 dependencies = [
  "async-trait",
+ "ethers",
  "hex 0.4.3",
  "hyperlane-core",
  "reqwest 0.11.27",

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6126,9 +6126,15 @@ dependencies = [
 name = "hyperlane-midnight"
 version = "2.2.0"
 dependencies = [
+ "async-trait",
+ "hex 0.4.3",
  "hyperlane-core",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
  "thiserror 1.0.63",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6127,9 +6127,12 @@ name = "hyperlane-midnight"
 version = "2.2.0"
 dependencies = [
  "async-trait",
+ "derive-new",
  "ethers",
  "hex 0.4.3",
  "hyperlane-core",
+ "hyperlane-operation-verifier",
+ "hyperlane-warp-route",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/rust/main/chains/hyperlane-midnight/Cargo.toml
+++ b/rust/main/chains/hyperlane-midnight/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
 
 async-trait = { workspace = true }
+ethers = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/rust/main/chains/hyperlane-midnight/Cargo.toml
+++ b/rust/main/chains/hyperlane-midnight/Cargo.toml
@@ -10,6 +10,11 @@ version.workspace = true
 [dependencies]
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
 
+async-trait = { workspace = true }
+hex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 # `macros` is required for feature unification: hyperlane-core's
 # `rpc_clients::fallback::test` module (unconditionally `pub`) uses
@@ -17,5 +22,7 @@ thiserror = { workspace = true }
 # workspace is built, other crates pull `macros` in transitively;
 # when running `cargo test -p hyperlane-midnight` standalone the
 # graph is too thin and `hyperlane-core` fails to compile without this.
-tokio = { workspace = true, features = ["macros"] }
+# `io-util` + `process` are needed by the toolkit subprocess wrapper.
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt-multi-thread"] }
+tracing = { workspace = true }
 url = { workspace = true }

--- a/rust/main/chains/hyperlane-midnight/Cargo.toml
+++ b/rust/main/chains/hyperlane-midnight/Cargo.toml
@@ -9,8 +9,11 @@ version.workspace = true
 
 [dependencies]
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
+hyperlane-operation-verifier = { path = "../../applications/hyperlane-operation-verifier" }
+hyperlane-warp-route = { path = "../../applications/hyperlane-warp-route" }
 
 async-trait = { workspace = true }
+derive-new = { workspace = true }
 ethers = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }

--- a/rust/main/chains/hyperlane-midnight/Cargo.toml
+++ b/rust/main/chains/hyperlane-midnight/Cargo.toml
@@ -26,3 +26,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "process", "rt-multi-thread"] }
 tracing = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/rust/main/chains/hyperlane-midnight/src/application.rs
+++ b/rust/main/chains/hyperlane-midnight/src/application.rs
@@ -1,0 +1,112 @@
+//! Application-level message verification for Midnight.
+//!
+//! The relayer calls into [`ApplicationOperationVerifier`] before delivering a
+//! message to its destination, so each chain integration can reject messages
+//! that its on-chain runtime would refuse anyway (e.g. malformed bodies).
+//!
+//! For Midnight, the only structural constraint we enforce at this layer is
+//! that warp-route messages must carry a parseable [`TokenMessage`]. Anything
+//! else is left to the on-chain Mailbox + ISM + WarpRoute to handle.
+
+use std::io::Cursor;
+
+use async_trait::async_trait;
+use derive_new::new;
+use tracing::trace;
+
+use hyperlane_core::{Decode, HyperlaneMessage};
+use hyperlane_operation_verifier::{
+    ApplicationOperationVerifier, ApplicationOperationVerifierReport,
+};
+use hyperlane_warp_route::TokenMessage;
+
+const WARP_ROUTE_MARKER: &str = "/";
+
+/// Application operation verifier for Midnight.
+#[derive(new)]
+pub struct MidnightApplicationOperationVerifier {}
+
+#[async_trait]
+impl ApplicationOperationVerifier for MidnightApplicationOperationVerifier {
+    async fn verify(
+        &self,
+        app_context: &Option<String>,
+        message: &HyperlaneMessage,
+    ) -> Option<ApplicationOperationVerifierReport> {
+        trace!(
+            ?app_context,
+            ?message,
+            "Midnight application operation verifier",
+        );
+
+        Self::verify_message(app_context, message)
+    }
+}
+
+impl MidnightApplicationOperationVerifier {
+    fn verify_message(
+        app_context: &Option<String>,
+        message: &HyperlaneMessage,
+    ) -> Option<ApplicationOperationVerifierReport> {
+        use ApplicationOperationVerifierReport::MalformedMessage;
+
+        let context = match app_context {
+            Some(c) => c,
+            None => return None,
+        };
+
+        if !context.contains(WARP_ROUTE_MARKER) {
+            return None;
+        }
+
+        let mut reader = Cursor::new(message.body.as_slice());
+        match TokenMessage::read_from(&mut reader) {
+            Ok(_) => None,
+            Err(_) => Some(MalformedMessage(message.clone())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperlane_core::{HyperlaneMessage, H256};
+
+    fn msg(body: Vec<u8>) -> HyperlaneMessage {
+        HyperlaneMessage {
+            version: 3,
+            nonce: 0,
+            origin: 1,
+            sender: H256::zero(),
+            destination: 2,
+            recipient: H256::zero(),
+            body,
+        }
+    }
+
+    #[test]
+    fn passes_without_app_context() {
+        assert!(MidnightApplicationOperationVerifier::verify_message(&None, &msg(vec![0u8; 16])).is_none());
+    }
+
+    #[test]
+    fn passes_non_warp_route_context() {
+        assert!(MidnightApplicationOperationVerifier::verify_message(
+            &Some("not-a-warp-route".to_string()),
+            &msg(vec![0u8; 16]),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn rejects_unparseable_warp_route_body() {
+        let result = MidnightApplicationOperationVerifier::verify_message(
+            &Some("warp/route".to_string()),
+            &msg(vec![]),
+        );
+        assert!(matches!(
+            result,
+            Some(ApplicationOperationVerifierReport::MalformedMessage(_))
+        ));
+    }
+}

--- a/rust/main/chains/hyperlane-midnight/src/config.rs
+++ b/rust/main/chains/hyperlane-midnight/src/config.rs
@@ -1,3 +1,4 @@
+use hyperlane_core::H160;
 use url::Url;
 
 /// Midnight connection configuration.
@@ -7,14 +8,29 @@ pub struct ConnectionConf {
     pub indexer_graphql_url: Url,
     /// Path to the handle submitter binary.
     pub toolkit_path: Option<String>,
+    /// Validator addresses registered on the destination Midnight contract,
+    /// in the same order the on-chain `validators` vector was set at
+    /// construction. The Mailbox uses this list to sort the signatures it
+    /// forwards to the submitter so the on-chain two-pointer multisig walk
+    /// accepts them. Empty when not supplied — `process()` then passes
+    /// signatures through in the order the relayer's metadata builder
+    /// produced them (matches pre-sort behaviour).
+    pub validators: Vec<H160>,
 }
 
 impl ConnectionConf {
-    /// Construct a new `ConnectionConf`.
+    /// Construct a new `ConnectionConf` with no validator list set.
     pub fn new(indexer_graphql_url: Url, toolkit_path: Option<String>) -> Self {
         Self {
             indexer_graphql_url,
             toolkit_path,
+            validators: Vec::new(),
         }
+    }
+
+    /// Builder: set the validator list used to sort multisig signatures.
+    pub fn with_validators(mut self, validators: Vec<H160>) -> Self {
+        self.validators = validators;
+        self
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/config.rs
+++ b/rust/main/chains/hyperlane-midnight/src/config.rs
@@ -15,22 +15,42 @@ pub struct ConnectionConf {
     /// accepts them. Empty when not supplied — `process()` then passes
     /// signatures through in the order the relayer's metadata builder
     /// produced them (matches pre-sort behaviour).
+    ///
+    /// TODO(#14): once a point-in-time state reader for the Midnight
+    /// indexer client lands, drop this field and read the validator set
+    /// from on-chain state directly. The `validators` + `threshold` pair
+    /// must migrate together to avoid set/threshold drift.
     pub validators: Vec<H160>,
+    /// Multisig threshold registered on the destination Midnight contract.
+    /// Used by `MultisigIsm::validators_and_threshold` to tell the relayer's
+    /// metadata builder how many signatures to fetch.
+    ///
+    /// TODO(#14): read this from chain state alongside `validators` once the
+    /// state reader is implemented.
+    pub threshold: u8,
 }
 
 impl ConnectionConf {
-    /// Construct a new `ConnectionConf` with no validator list set.
+    /// Construct a new `ConnectionConf` with no validator list set and a
+    /// zero threshold. Both must be set via builder methods before use.
     pub fn new(indexer_graphql_url: Url, toolkit_path: Option<String>) -> Self {
         Self {
             indexer_graphql_url,
             toolkit_path,
             validators: Vec::new(),
+            threshold: 0,
         }
     }
 
     /// Builder: set the validator list used to sort multisig signatures.
     pub fn with_validators(mut self, validators: Vec<H160>) -> Self {
         self.validators = validators;
+        self
+    }
+
+    /// Builder: set the multisig threshold reported to the relayer.
+    pub fn with_threshold(mut self, threshold: u8) -> Self {
+        self.threshold = threshold;
         self
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/config.rs
+++ b/rust/main/chains/hyperlane-midnight/src/config.rs
@@ -1,21 +1,11 @@
 use url::Url;
 
 /// Midnight connection configuration.
-///
-/// Contract addresses flow via the standard `CoreContractAddresses` struct
-/// at the `ChainConf` level, not this struct. Native token metadata flows via
-/// `ChainConf.native_token`.
 #[derive(Clone, Debug)]
 pub struct ConnectionConf {
-    /// GraphQL URL for the Midnight indexer (primary data source for reads).
+    /// GraphQL URL for the Midnight indexer.
     pub indexer_graphql_url: Url,
-    /// Filesystem path to the Midnight handle submitter binary used by the
-    /// Classic `Mailbox::process` implementation. The submitter reads a
-    /// JSON payload on stdin and writes a JSON envelope on stdout (see
-    /// `toolkit.rs` for the protocol). In the devnet workflow this points
-    /// at the `relayer/dist/submit-handle.js` entrypoint in
-    /// `equilibriumco/hyperlane-midnight`. Optional — `process` returns
-    /// `HyperlaneMidnightError::MissingSubmitterPath` if absent.
+    /// Path to the handle submitter binary.
     pub toolkit_path: Option<String>,
 }
 

--- a/rust/main/chains/hyperlane-midnight/src/config.rs
+++ b/rust/main/chains/hyperlane-midnight/src/config.rs
@@ -9,9 +9,13 @@ use url::Url;
 pub struct ConnectionConf {
     /// GraphQL URL for the Midnight indexer (primary data source for reads).
     pub indexer_graphql_url: Url,
-    /// Filesystem path to the `midnight-node-toolkit` binary used by the
-    /// Classic `Mailbox::process` implementation (issue #20). Optional at
-    /// scaffolding time (#13).
+    /// Filesystem path to the Midnight handle submitter binary used by the
+    /// Classic `Mailbox::process` implementation. The submitter reads a
+    /// JSON payload on stdin and writes a JSON envelope on stdout (see
+    /// `toolkit.rs` for the protocol). In the devnet workflow this points
+    /// at the `relayer/dist/submit-handle.js` entrypoint in
+    /// `equilibriumco/hyperlane-midnight`. Optional — `process` returns
+    /// `HyperlaneMidnightError::MissingSubmitterPath` if absent.
     pub toolkit_path: Option<String>,
 }
 

--- a/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
+++ b/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
@@ -1,0 +1,303 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use hyperlane_core::{
+    ContractLocator, HyperlaneChain, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider,
+    KnownHyperlaneDomain, Mailbox, Metadata, ReorgPeriod, H256,
+};
+use tempfile::TempDir;
+use url::Url;
+
+use crate::{ConnectionConf, MidnightMailbox};
+
+struct StubSubmitter {
+    _dir: TempDir,
+    binary: PathBuf,
+    request_log: PathBuf,
+}
+
+impl StubSubmitter {
+    fn always_returns(response_json: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("submit");
+        let request_log = dir.path().join("request.json");
+
+        let script = format!(
+            "#!/bin/sh\ncat > '{log}'\ncat <<'__SUBMITTER_RESPONSE__'\n{resp}\n__SUBMITTER_RESPONSE__\n",
+            log = request_log.display(),
+            resp = response_json,
+        );
+        std::fs::write(&binary, script).unwrap();
+        let mut perms = std::fs::metadata(&binary).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&binary, perms).unwrap();
+
+        Self {
+            _dir: dir,
+            binary,
+            request_log,
+        }
+    }
+
+    fn binary_path(&self) -> &str {
+        self.binary.to_str().unwrap()
+    }
+
+    fn captured_request(&self) -> serde_json::Value {
+        let raw = std::fs::read_to_string(&self.request_log).expect("stub captured no stdin");
+        serde_json::from_str(&raw).expect("captured stdin is not valid JSON")
+    }
+}
+
+const TEST_CONTRACT_ADDRESS: H256 = H256::repeat_byte(0xA1);
+
+fn build_mailbox(stub: &StubSubmitter) -> MidnightMailbox {
+    let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Midnight);
+    let locator = ContractLocator {
+        domain: &domain,
+        address: TEST_CONTRACT_ADDRESS,
+    };
+    let conf = ConnectionConf::new(
+        Url::parse("http://127.0.0.1:8088/api/v3/graphql").unwrap(),
+        Some(stub.binary_path().to_owned()),
+    );
+    MidnightMailbox::new(&locator, &conf).unwrap()
+}
+
+fn sample_message() -> HyperlaneMessage {
+    HyperlaneMessage {
+        version: 3,
+        nonce: 0,
+        origin: 5,
+        sender: H256::repeat_byte(0xAB),
+        destination: 1234,
+        recipient: H256::repeat_byte(0x44),
+        body: vec![0u8; 64],
+    }
+}
+
+fn sample_metadata() -> Metadata {
+    let mut bytes = Vec::with_capacity(32 + 32 + 4 + 2 * 65);
+    bytes.extend_from_slice(&[0xCD; 32]);
+    bytes.extend_from_slice(&[0xEE; 32]);
+    bytes.extend_from_slice(&7u32.to_be_bytes());
+    bytes.extend_from_slice(&[0x11; 65]);
+    bytes.extend_from_slice(&[0x22; 65]);
+    Metadata::new(bytes)
+}
+
+#[tokio::test]
+async fn delivered_resolves_true_response_to_true() {
+    let stub = StubSubmitter::always_returns(r#"{"delivered":true}"#);
+    let mailbox = build_mailbox(&stub);
+    assert!(mailbox.delivered(H256::repeat_byte(0xCC)).await.unwrap());
+}
+
+#[tokio::test]
+async fn delivered_resolves_false_response_to_false() {
+    let stub = StubSubmitter::always_returns(r#"{"delivered":false}"#);
+    let mailbox = build_mailbox(&stub);
+    assert!(!mailbox.delivered(H256::repeat_byte(0xCC)).await.unwrap());
+}
+
+#[tokio::test]
+async fn delivered_propagates_submitter_error_as_structured_kind() {
+    let stub = StubSubmitter::always_returns(
+        r#"{"error":{"kind":"rpcUnreachable","message":"econnrefused"}}"#,
+    );
+    let mailbox = build_mailbox(&stub);
+    let err = mailbox.delivered(H256::zero()).await.unwrap_err();
+    assert!(format!("{err}").contains("rpcUnreachable"));
+}
+
+#[tokio::test]
+async fn is_contract_returns_true_for_monolithic_warp_route() {
+    // Returning false makes `pending_message` drop every inbound message
+    // at the `is_recipient_contract` gate before `Mailbox::process` runs.
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    let is_contract = mailbox
+        .provider()
+        .is_contract(&H256::repeat_byte(0x77))
+        .await
+        .unwrap();
+    assert!(is_contract);
+}
+
+#[tokio::test]
+async fn process_request_json_pins_wire_shape() {
+    let stub = StubSubmitter::always_returns(r#"{"txHash":"0x42","blockHeight":1}"#);
+    let mailbox = build_mailbox(&stub);
+
+    mailbox
+        .process(&sample_message(), &sample_metadata(), None)
+        .await
+        .unwrap();
+
+    let req = stub.captured_request();
+    assert_eq!(req["op"], "submit");
+    assert_eq!(req["contractAddress"], format!("0x{TEST_CONTRACT_ADDRESS:x}"));
+    assert_eq!(req["isContractRecipient"], false);
+
+    let msg = &req["message"];
+    assert_eq!(msg["version"], 3);
+    assert_eq!(msg["nonce"], "0");
+    assert_eq!(msg["origin"], 5);
+    assert_eq!(msg["destination"], 1234);
+    assert!(msg["sender"].as_str().unwrap().starts_with("0x"));
+    assert!(msg["recipient"].as_str().unwrap().starts_with("0x"));
+    assert!(msg["body"].as_str().unwrap().starts_with("0x"));
+
+    let md = &req["metadata"];
+    assert_eq!(
+        md["merkleTreeHook"].as_str().unwrap(),
+        format!("0x{}", hex::encode([0xCD; 32]))
+    );
+    assert_eq!(
+        md["root"].as_str().unwrap(),
+        format!("0x{}", hex::encode([0xEE; 32]))
+    );
+    assert_eq!(md["index"], 7);
+
+    let sigs = md["signatures"].as_array().unwrap();
+    assert_eq!(sigs.len(), 16);
+    assert_eq!(sigs[0].as_str().unwrap(), format!("0x{}", hex::encode([0x11; 65])));
+    assert_eq!(sigs[1].as_str().unwrap(), format!("0x{}", hex::encode([0x22; 65])));
+    assert_eq!(sigs[2].as_str().unwrap(), format!("0x{}", hex::encode([0u8; 65])));
+}
+
+#[tokio::test]
+async fn delivered_request_json_pins_wire_shape() {
+    let stub = StubSubmitter::always_returns(r#"{"delivered":false}"#);
+    let mailbox = build_mailbox(&stub);
+
+    let msg_id = H256::repeat_byte(0xAA);
+    mailbox.delivered(msg_id).await.unwrap();
+
+    let req = stub.captured_request();
+    assert_eq!(req["op"], "isDelivered");
+    assert_eq!(req["contractAddress"], format!("0x{TEST_CONTRACT_ADDRESS:x}"));
+    assert_eq!(req["messageId"], format!("0x{msg_id:x}"));
+    assert!(req["indexerGraphqlUrl"].as_str().unwrap().contains("graphql"));
+}
+
+#[tokio::test]
+async fn process_returns_tx_outcome_on_success() {
+    let stub = StubSubmitter::always_returns(r#"{"txHash":"0xdeadbeef","blockHeight":12345}"#);
+    let mailbox = build_mailbox(&stub);
+
+    let outcome = mailbox
+        .process(&sample_message(), &sample_metadata(), None)
+        .await
+        .unwrap();
+    assert!(outcome.executed);
+    let raw = outcome.transaction_id.as_bytes();
+    assert_eq!(&raw[..4], &[0xde, 0xad, 0xbe, 0xef]);
+}
+
+#[tokio::test]
+async fn process_maps_replay_response_to_submitter_reported() {
+    let stub = StubSubmitter::always_returns(
+        r#"{"error":{"kind":"replay","message":"already delivered"}}"#,
+    );
+    let mailbox = build_mailbox(&stub);
+    let err = mailbox
+        .process(&sample_message(), &sample_metadata(), None)
+        .await
+        .unwrap_err();
+    assert!(format!("{err}").contains("replay"));
+}
+
+#[tokio::test]
+async fn process_maps_contract_revert_response_to_submitter_reported() {
+    let stub = StubSubmitter::always_returns(
+        r#"{"error":{"kind":"contractRevert","message":"failed assert: Routes: domain not enrolled"}}"#,
+    );
+    let mailbox = build_mailbox(&stub);
+    let err = mailbox
+        .process(&sample_message(), &sample_metadata(), None)
+        .await
+        .unwrap_err();
+    let display = format!("{err}");
+    assert!(display.contains("contractRevert"));
+    assert!(display.contains("Routes: domain not enrolled"));
+}
+
+#[tokio::test]
+async fn process_rejects_malformed_response_as_malformed() {
+    let stub = StubSubmitter::always_returns("not even json");
+    let mailbox = build_mailbox(&stub);
+    let err = mailbox
+        .process(&sample_message(), &sample_metadata(), None)
+        .await
+        .unwrap_err();
+    let display = format!("{err}").to_lowercase();
+    assert!(display.contains("malformed") || display.contains("expected"));
+}
+
+#[tokio::test]
+async fn default_ism_returns_contract_address() {
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    assert_eq!(
+        Mailbox::default_ism(&mailbox).await.unwrap(),
+        TEST_CONTRACT_ADDRESS
+    );
+}
+
+#[tokio::test]
+async fn recipient_ism_returns_contract_address_for_any_recipient() {
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    assert_eq!(
+        mailbox.recipient_ism(H256::repeat_byte(0xEE)).await.unwrap(),
+        TEST_CONTRACT_ADDRESS
+    );
+}
+
+#[tokio::test]
+async fn count_returns_zero_for_destination_only_impl() {
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    assert_eq!(mailbox.count(&ReorgPeriod::None).await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn process_estimate_costs_returns_non_zero_placeholder() {
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    let estimate = mailbox
+        .process_estimate_costs(&sample_message(), &sample_metadata())
+        .await
+        .unwrap();
+    assert!(!estimate.gas_limit.is_zero());
+}
+
+#[tokio::test]
+async fn process_calldata_is_unimplemented_lander_only() {
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    let err = mailbox
+        .process_calldata(&sample_message(), &sample_metadata())
+        .await
+        .unwrap_err();
+    let display = format!("{err}").to_lowercase();
+    assert!(display.contains("not implemented") || display.contains("lander"));
+}
+
+#[tokio::test]
+async fn delivered_calldata_returns_none_lander_only() {
+    let stub = StubSubmitter::always_returns("{}");
+    let mailbox = build_mailbox(&stub);
+    assert!(mailbox.delivered_calldata(H256::zero()).unwrap().is_none());
+}
+
+#[tokio::test]
+async fn stub_captures_full_payload_for_inspection() {
+    let stub = StubSubmitter::always_returns(r#"{"delivered":true}"#);
+    let mailbox = build_mailbox(&stub);
+    mailbox.delivered(H256::repeat_byte(0xBB)).await.unwrap();
+    let req = stub.captured_request();
+    assert!(req.is_object());
+    assert_eq!(req["op"], "isDelivered");
+}

--- a/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
+++ b/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
@@ -136,7 +136,7 @@ async fn process_request_json_pins_wire_shape() {
 
     let req = stub.captured_request();
     assert_eq!(req["op"], "submit");
-    assert_eq!(req["contractAddress"], format!("0x{TEST_CONTRACT_ADDRESS:x}"));
+    assert_eq!(req["contractAddress"], format!("{TEST_CONTRACT_ADDRESS:x}"));
     assert_eq!(req["isContractRecipient"], false);
 
     let msg = &req["message"];
@@ -176,7 +176,7 @@ async fn delivered_request_json_pins_wire_shape() {
 
     let req = stub.captured_request();
     assert_eq!(req["op"], "isDelivered");
-    assert_eq!(req["contractAddress"], format!("0x{TEST_CONTRACT_ADDRESS:x}"));
+    assert_eq!(req["contractAddress"], format!("{TEST_CONTRACT_ADDRESS:x}"));
     assert_eq!(req["messageId"], format!("0x{msg_id:x}"));
     assert!(req["indexerGraphqlUrl"].as_str().unwrap().contains("graphql"));
 }

--- a/rust/main/chains/hyperlane-midnight/src/error.rs
+++ b/rust/main/chains/hyperlane-midnight/src/error.rs
@@ -3,10 +3,64 @@ use hyperlane_core::ChainCommunicationError;
 /// Errors produced by the `hyperlane-midnight` crate.
 #[derive(Debug, thiserror::Error)]
 pub enum HyperlaneMidnightError {
-    /// Feature not implemented yet — replaced in issues #14–#20.
+    /// Feature not implemented yet.
     #[error("Midnight: {0} not implemented yet")]
     NotImplemented(&'static str),
-    /// Other errors.
+
+    /// The configured submitter binary path is empty.
+    #[error("Midnight submitter path is not configured (set `toolkitPath` in the chain config)")]
+    MissingSubmitterPath,
+
+    /// Failed to spawn the submitter subprocess.
+    #[error("failed to spawn submitter `{path}`: {source}")]
+    SubmitterSpawn {
+        /// Path that the agent attempted to spawn.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Submitter exited with a non-zero status code.
+    #[error("submitter exited with status {status}; stderr: {stderr}")]
+    SubmitterFailed {
+        /// Process exit status (numeric for cross-platform).
+        status: i32,
+        /// Captured stderr from the subprocess.
+        stderr: String,
+    },
+
+    /// Submitter produced output that could not be parsed.
+    #[error("submitter returned malformed JSON: {message} (raw: {raw})")]
+    SubmitterMalformed {
+        /// Parser error message.
+        message: String,
+        /// Raw stdout the parser failed on (truncated upstream if very long).
+        raw: String,
+    },
+
+    /// Submitter reported a structured error in its JSON response.
+    #[error("submitter reported error: {kind}: {message}")]
+    SubmitterReported {
+        /// Short kind tag from the submitter (e.g. `proofTimeout`, `insufficientDust`).
+        kind: String,
+        /// Human-readable message from the submitter.
+        message: String,
+    },
+
+    /// The indexer GraphQL endpoint returned an error.
+    #[error("indexer GraphQL error: {0}")]
+    IndexerGraphql(String),
+
+    /// HTTP transport failure talking to the indexer.
+    #[error("indexer HTTP error: {0}")]
+    IndexerHttp(#[from] reqwest::Error),
+
+    /// JSON failure in the indexer client path.
+    #[error("indexer JSON error: {0}")]
+    IndexerJson(#[from] serde_json::Error),
+
+    /// Generic catch-all for anything else.
     #[error("{0}")]
     Other(String),
 }

--- a/rust/main/chains/hyperlane-midnight/src/error.rs
+++ b/rust/main/chains/hyperlane-midnight/src/error.rs
@@ -30,6 +30,14 @@ pub enum HyperlaneMidnightError {
         stderr: String,
     },
 
+    /// Submitter did not exit within the configured wall-clock budget.
+    /// The child is SIGKILLed via `kill_on_drop` before this is raised.
+    #[error("submitter exceeded {elapsed_secs}s timeout (SIGKILLed)")]
+    SubmitterTimeout {
+        /// Wall-clock budget in seconds, for surfacing in logs/metrics.
+        elapsed_secs: u64,
+    },
+
     /// Submitter produced output that could not be parsed.
     #[error("submitter returned malformed JSON: {message} (raw: {raw})")]
     SubmitterMalformed {

--- a/rust/main/chains/hyperlane-midnight/src/error.rs
+++ b/rust/main/chains/hyperlane-midnight/src/error.rs
@@ -7,7 +7,7 @@ pub enum HyperlaneMidnightError {
     #[error("Midnight: {0} not implemented yet")]
     NotImplemented(&'static str),
 
-    /// The configured submitter binary path is empty.
+    /// Submitter path is unset.
     #[error("Midnight submitter path is not configured (set `toolkitPath` in the chain config)")]
     MissingSubmitterPath,
 
@@ -24,39 +24,38 @@ pub enum HyperlaneMidnightError {
     /// Submitter exited with a non-zero status code.
     #[error("submitter exited with status {status}; stderr: {stderr}")]
     SubmitterFailed {
-        /// Process exit status (numeric for cross-platform).
+        /// Process exit status.
         status: i32,
-        /// Captured stderr from the subprocess.
+        /// Captured stderr.
         stderr: String,
     },
 
-    /// Submitter did not exit within the configured wall-clock budget.
-    /// The child is SIGKILLed via `kill_on_drop` before this is raised.
+    /// Submitter did not exit within the wall-clock budget.
     #[error("submitter exceeded {elapsed_secs}s timeout (SIGKILLed)")]
     SubmitterTimeout {
-        /// Wall-clock budget in seconds, for surfacing in logs/metrics.
+        /// Wall-clock budget in seconds.
         elapsed_secs: u64,
     },
 
-    /// Submitter produced output that could not be parsed.
+    /// Submitter stdout could not be parsed as JSON.
     #[error("submitter returned malformed JSON: {message} (raw: {raw})")]
     SubmitterMalformed {
-        /// Parser error message.
+        /// Parser error.
         message: String,
-        /// Raw stdout the parser failed on (truncated upstream if very long).
+        /// Raw stdout.
         raw: String,
     },
 
-    /// Submitter reported a structured error in its JSON response.
+    /// Submitter reported a structured error.
     #[error("submitter reported error: {kind}: {message}")]
     SubmitterReported {
-        /// Short kind tag from the submitter (e.g. `proofTimeout`, `insufficientDust`).
+        /// Short kind tag.
         kind: String,
-        /// Human-readable message from the submitter.
+        /// Human-readable message.
         message: String,
     },
 
-    /// The indexer GraphQL endpoint returned an error.
+    /// Indexer GraphQL error.
     #[error("indexer GraphQL error: {0}")]
     IndexerGraphql(String),
 
@@ -68,7 +67,7 @@ pub enum HyperlaneMidnightError {
     #[error("indexer JSON error: {0}")]
     IndexerJson(#[from] serde_json::Error),
 
-    /// Generic catch-all for anything else.
+    /// Catch-all.
     #[error("{0}")]
     Other(String),
 }

--- a/rust/main/chains/hyperlane-midnight/src/indexer_client.rs
+++ b/rust/main/chains/hyperlane-midnight/src/indexer_client.rs
@@ -1,0 +1,107 @@
+//! Thin GraphQL client for the Midnight indexer.
+//!
+//! Only the queries needed by the destination-side Mailbox path live here.
+//! The full indexer-driven message + delivery indexer arrives with issue #16.
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::HyperlaneMidnightError;
+
+/// HTTP client wrapper around the indexer's GraphQL endpoint.
+#[derive(Debug, Clone)]
+pub struct MidnightIndexerClient {
+    endpoint: Url,
+    http: reqwest::Client,
+}
+
+impl MidnightIndexerClient {
+    /// Build a client pointed at the given GraphQL HTTP endpoint.
+    pub fn new(endpoint: Url) -> Self {
+        Self {
+            endpoint,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Latest known block height (used as a heartbeat / liveness check).
+    /// Returns `None` if the indexer hasn't observed any blocks yet.
+    ///
+    /// The destination-side Mailbox doesn't actually read this — it's
+    /// included so [`HyperlaneProvider`] can implement `get_block_by_height`
+    /// without re-wiring a second client later. Bigger surface lands in
+    /// issue #14.
+    pub async fn latest_block_height(&self) -> Result<Option<u64>, HyperlaneMidnightError> {
+        let query = r#"query { block { height } }"#;
+        let body = GraphqlRequest {
+            query,
+            variables: serde_json::Value::Null,
+        };
+
+        let response: GraphqlResponse<LatestBlock> = self.post(&body).await?;
+        if let Some(errors) = response.errors {
+            if !errors.is_empty() {
+                return Err(HyperlaneMidnightError::IndexerGraphql(
+                    errors
+                        .into_iter()
+                        .map(|e| e.message)
+                        .collect::<Vec<_>>()
+                        .join("; "),
+                ));
+            }
+        }
+        Ok(response.data.and_then(|d| d.block.map(|b| b.height)))
+    }
+
+    async fn post<T: for<'de> Deserialize<'de>>(
+        &self,
+        body: &GraphqlRequest<'_>,
+    ) -> Result<GraphqlResponse<T>, HyperlaneMidnightError> {
+        let response = self
+            .http
+            .post(self.endpoint.clone())
+            .json(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let bytes = response.bytes().await?;
+
+        if !status.is_success() {
+            return Err(HyperlaneMidnightError::IndexerGraphql(format!(
+                "HTTP {status}: {}",
+                String::from_utf8_lossy(&bytes)
+            )));
+        }
+
+        let parsed: GraphqlResponse<T> = serde_json::from_slice(&bytes)?;
+        Ok(parsed)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GraphqlRequest<'a> {
+    query: &'a str,
+    variables: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlResponse<T> {
+    data: Option<T>,
+    errors: Option<Vec<GraphqlError>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LatestBlock {
+    #[serde(default)]
+    block: Option<BlockHeight>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlockHeight {
+    height: u64,
+}

--- a/rust/main/chains/hyperlane-midnight/src/indexer_client.rs
+++ b/rust/main/chains/hyperlane-midnight/src/indexer_client.rs
@@ -1,14 +1,9 @@
-//! Thin GraphQL client for the Midnight indexer.
-//!
-//! Only the queries needed by the destination-side Mailbox path live here.
-//! The full indexer-driven message + delivery indexer arrives with issue #16.
-
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::HyperlaneMidnightError;
 
-/// HTTP client wrapper around the indexer's GraphQL endpoint.
+/// HTTP client for the Midnight indexer's GraphQL endpoint.
 #[derive(Debug, Clone)]
 pub struct MidnightIndexerClient {
     endpoint: Url,
@@ -24,13 +19,7 @@ impl MidnightIndexerClient {
         }
     }
 
-    /// Latest known block height (used as a heartbeat / liveness check).
-    /// Returns `None` if the indexer hasn't observed any blocks yet.
-    ///
-    /// The destination-side Mailbox doesn't actually read this — it's
-    /// included so [`HyperlaneProvider`] can implement `get_block_by_height`
-    /// without re-wiring a second client later. Bigger surface lands in
-    /// issue #14.
+    /// Latest known block height, or `None` if the indexer has not observed any yet.
     pub async fn latest_block_height(&self) -> Result<Option<u64>, HyperlaneMidnightError> {
         let query = r#"query { block { height } }"#;
         let body = GraphqlRequest {

--- a/rust/main/chains/hyperlane-midnight/src/ism.rs
+++ b/rust/main/chains/hyperlane-midnight/src/ism.rs
@@ -1,0 +1,152 @@
+//! `InterchainSecurityModule` + `MultisigIsm` impls for Midnight.
+//!
+//! These return a hardcoded `ModuleType::MessageIdMultisig` and a
+//! `(validators, threshold)` pair read from `ConnectionConf`. The Midnight
+//! WarpRoute's on-chain ISM is a `MessageIdMultisigIsm` by design — there's
+//! one ISM variant in the protocol today — so the static module type is
+//! correct, not a workaround. The validator set + threshold IS a
+//! workaround: agent operators must keep the agent config in lockstep with
+//! on-chain state.
+//!
+//! TODO(#14): once the Midnight indexer client gains a point-in-time state
+//! reader, read `validators`, `threshold`, **and** module type from chain
+//! state at metadata-build time. `validators` and `threshold` should
+//! migrate together — set/threshold drift would either soft-brick delivery
+//! (relayer signs against the wrong set) or invalidate the on-chain check.
+//! `module_type()` should detect the variant from chain state instead of
+//! hardcoding, so additional ISM types (e.g. MerkleRootMultisig,
+//! AggregationIsm) can be added without code changes.
+
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage,
+    HyperlaneProvider, InterchainSecurityModule, Metadata, ModuleType, MultisigIsm, H160, H256,
+    U256,
+};
+
+use crate::{ConnectionConf, MidnightProvider};
+
+/// Config-sourced `InterchainSecurityModule` for Midnight. Returns
+/// `MessageIdMultisig` — the only ISM variant the Midnight WarpRoute
+/// supports today.
+#[derive(Debug)]
+pub struct MidnightInterchainSecurityModule {
+    address: H256,
+    domain: HyperlaneDomain,
+    provider: MidnightProvider,
+}
+
+impl MidnightInterchainSecurityModule {
+    /// Construct a new ISM handle.
+    pub fn new(address: H256, domain: HyperlaneDomain, provider: MidnightProvider) -> Self {
+        Self {
+            address,
+            domain,
+            provider,
+        }
+    }
+}
+
+impl HyperlaneChain for MidnightInterchainSecurityModule {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.provider.clone())
+    }
+}
+
+impl HyperlaneContract for MidnightInterchainSecurityModule {
+    fn address(&self) -> H256 {
+        self.address
+    }
+}
+
+#[async_trait]
+impl InterchainSecurityModule for MidnightInterchainSecurityModule {
+    async fn module_type(&self) -> ChainResult<ModuleType> {
+        Ok(ModuleType::MessageIdMultisig)
+    }
+
+    async fn dry_run_verify(
+        &self,
+        _message: &HyperlaneMessage,
+        _metadata: &Metadata,
+    ) -> ChainResult<Option<U256>> {
+        // Midnight uses DUST-based fees the wallet computes at submission
+        // time (same pattern as `MidnightMailbox::process_estimate_costs`).
+        // Returning `None` signals "I can't estimate" — the relayer falls
+        // back to its own logic without dry-running, which is fine.
+        Ok(None)
+    }
+}
+
+/// Config-sourced `MultisigIsm` for Midnight.
+#[derive(Debug)]
+pub struct MidnightMultisigIsm {
+    address: H256,
+    domain: HyperlaneDomain,
+    provider: MidnightProvider,
+    validators: Vec<H160>,
+    threshold: u8,
+}
+
+impl MidnightMultisigIsm {
+    /// Construct from `ConnectionConf`'s validator list + threshold.
+    pub fn new(
+        address: H256,
+        domain: HyperlaneDomain,
+        provider: MidnightProvider,
+        conf: &ConnectionConf,
+    ) -> Self {
+        Self {
+            address,
+            domain,
+            provider,
+            validators: conf.validators.clone(),
+            threshold: conf.threshold,
+        }
+    }
+}
+
+impl HyperlaneChain for MidnightMultisigIsm {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.provider.clone())
+    }
+}
+
+impl HyperlaneContract for MidnightMultisigIsm {
+    fn address(&self) -> H256 {
+        self.address
+    }
+}
+
+#[async_trait]
+impl MultisigIsm for MidnightMultisigIsm {
+    async fn validators_and_threshold(
+        &self,
+        _message: &HyperlaneMessage,
+    ) -> ChainResult<(Vec<H256>, u8)> {
+        // ETH validator addresses are stored as H160 in ConnectionConf to
+        // match the on-chain Midnight contract's `Bytes<20>` field. The
+        // multisig metadata pipeline expects H256, so left-pad each
+        // address with 12 zero bytes — this matches Ethereum's standard
+        // `addressToBytes32` convention used elsewhere in the codebase.
+        let padded: Vec<H256> = self
+            .validators
+            .iter()
+            .map(|addr| {
+                let mut bytes = [0u8; 32];
+                bytes[12..].copy_from_slice(addr.as_bytes());
+                H256::from(bytes)
+            })
+            .collect();
+        Ok((padded, self.threshold))
+    }
+}

--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -3,12 +3,15 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod application;
 mod config;
 mod error;
 mod indexer_client;
+pub mod ism;
 mod mailbox;
 mod provider;
 mod signer;
+pub mod stubs;
 mod toolkit;
 
 #[cfg(test)]

--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -11,6 +11,9 @@ mod provider;
 mod signer;
 mod toolkit;
 
+#[cfg(test)]
+mod cross_boundary_tests;
+
 pub use config::ConnectionConf;
 pub use error::HyperlaneMidnightError;
 pub use indexer_client::MidnightIndexerClient;

--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -1,13 +1,4 @@
 //! Hyperlane Midnight chain integration.
-//!
-//! Issue #13 (T16) landed the scaffolding (config + signer placeholders +
-//! framework wiring). Issue #20 adds destination-side `Mailbox` delivery:
-//! the `MidnightMailbox` parses MessageIdMultisigIsmMetadata and shells out
-//! to a submitter binary (Node script in `equilibriumco/hyperlane-midnight`)
-//! to invoke the `handle` circuit on the deployed WarpRoute contract.
-//!
-//! Outbound dispatch, ValidatorAnnounce, IGP, and the full indexer client
-//! arrive with issues #9 / #10 / #11 / #12 / #14 / #15 / #16 / #33.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -1,17 +1,28 @@
-//! Scaffolding for the Midnight chain integration.
+//! Hyperlane Midnight chain integration.
 //!
-//! Issue #13 (T16): framework wiring only. Real trait impls (Mailbox, indexers,
-//! ValidatorAnnounce, provider) land in issues #14–#20. Transaction submission
-//! uses the Classic submitter path, shelling out to `midnight-node-toolkit`
-//! (see issue #20).
+//! Issue #13 (T16) landed the scaffolding (config + signer placeholders +
+//! framework wiring). Issue #20 adds destination-side `Mailbox` delivery:
+//! the `MidnightMailbox` parses MessageIdMultisigIsmMetadata and shells out
+//! to a submitter binary (Node script in `equilibriumco/hyperlane-midnight`)
+//! to invoke the `handle` circuit on the deployed WarpRoute contract.
+//!
+//! Outbound dispatch, ValidatorAnnounce, IGP, and the full indexer client
+//! arrive with issues #9 / #10 / #11 / #12 / #14 / #15 / #16 / #33.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 mod config;
 mod error;
+mod indexer_client;
+mod mailbox;
+mod provider;
 mod signer;
+mod toolkit;
 
 pub use config::ConnectionConf;
 pub use error::HyperlaneMidnightError;
+pub use indexer_client::MidnightIndexerClient;
+pub use mailbox::MidnightMailbox;
+pub use provider::MidnightProvider;
 pub use signer::MidnightSigner;

--- a/rust/main/chains/hyperlane-midnight/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-midnight/src/mailbox.rs
@@ -1,12 +1,3 @@
-//! Destination-side `Mailbox` implementation for Midnight.
-//!
-//! The relayer calls `process(message, metadata, ...)` once it has gathered a
-//! signed checkpoint quorum. This impl parses the canonical
-//! MessageIdMultisigIsmMetadata layout, packages the fields as JSON, and
-//! spawns the Midnight handle submitter as a subprocess. The submitter
-//! (TypeScript, in `equilibriumco/hyperlane-midnight`) generates the ZK
-//! proof and broadcasts the `handle` circuit call.
-
 use std::str::FromStr;
 
 use async_trait::async_trait;
@@ -20,19 +11,11 @@ use hyperlane_core::{
 use crate::toolkit::{self, ToolkitContext, WireMetadata};
 use crate::{ConnectionConf, HyperlaneMidnightError, MidnightIndexerClient, MidnightProvider};
 
-/// Maximum signature slots in the on-chain `Vector<16, Bytes<65>>`. Mirrors
-/// `MAX_VALIDATORS` in the Compact contract.
 const MAX_SIGNATURES: usize = 16;
-/// Length of a single signature (`r || s || v`).
 const SIGNATURE_LEN: usize = 65;
-/// MessageIdMultisigIsmMetadata layout header length:
-/// `merkle_tree_hook (32) || root (32) || index (4)`.
 const METADATA_HEADER_LEN: usize = 32 + 32 + 4;
 
-/// Default proof-server endpoint used when the env override is unset. Keeps
-/// the devnet shape (see `hyperlane-midnight/devnet/src/config.ts`).
 const DEFAULT_PROOF_SERVER_URL: &str = "http://127.0.0.1:6300";
-/// Default Midnight network id when not overridden via env.
 const DEFAULT_NETWORK_ID: &str = "undeployed";
 
 /// Destination-side Mailbox.
@@ -45,9 +28,7 @@ pub struct MidnightMailbox {
 }
 
 impl MidnightMailbox {
-    /// Build a new Mailbox bound to the given chain config and contract
-    /// locator. The provider exposes the indexer URL for `HyperlaneChain`
-    /// consumers; the toolkit context drives `process`.
+    /// Build a new Mailbox.
     pub fn new(locator: &ContractLocator<'_>, conf: &ConnectionConf) -> ChainResult<Self> {
         let indexer = MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
         let provider = MidnightProvider::new(locator.domain.clone(), indexer);
@@ -79,8 +60,6 @@ impl MidnightMailbox {
     }
 }
 
-/// Convert the indexer's HTTP URL to a WebSocket URL using the same path
-/// convention midnight-indexer ships (`/graphql/ws` alongside `/graphql`).
 fn derive_ws_url(http: &url::Url) -> String {
     let mut ws = http.clone();
     let scheme = match http.scheme() {
@@ -113,9 +92,6 @@ impl HyperlaneContract for MidnightMailbox {
 
 #[async_trait]
 impl Mailbox for MidnightMailbox {
-    /// Destination-side has no dispatch nonce to report. The relayer doesn't
-    /// rely on this value for inbound delivery; the proper outbound count
-    /// arrives with #9 + #16.
     async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
         Ok(0)
     }
@@ -124,15 +100,10 @@ impl Mailbox for MidnightMailbox {
         toolkit::query_delivered(&self.toolkit_ctx, self.address, id).await
     }
 
-    /// The WarpRoute is monolithic — the Mailbox, ISM, hook, and warp logic
-    /// all live in one contract, so the "default ISM" address is this
-    /// contract's own address.
     async fn default_ism(&self) -> ChainResult<H256> {
         Ok(self.address)
     }
 
-    /// Same monolithic contract — every recipient routes through the same
-    /// embedded MessageIdMultisigIsm.
     async fn recipient_ism(&self, _recipient: H256) -> ChainResult<H256> {
         Ok(self.address)
     }
@@ -144,24 +115,11 @@ impl Mailbox for MidnightMailbox {
         _tx_gas_limit: Option<U256>,
     ) -> ChainResult<TxOutcome> {
         let parsed = parse_metadata(metadata.as_ref())?;
-        let request = toolkit::build_request(
-            self.address,
-            &self.toolkit_ctx,
-            message,
-            parsed,
-            // The destination-side WarpRoute is user-facing. Contract
-            // recipients are out of scope until the warp route grows a
-            // routing layer; default to false so `sendUnshielded` lands as
-            // `UserAddress`.
-            false,
-        );
+        let request =
+            toolkit::build_request(self.address, &self.toolkit_ctx, message, parsed, false);
 
         let outcome = toolkit::submit_handle(&self.toolkit_ctx, &request).await?;
 
-        // The submitter only returns success when the on-chain replay set
-        // was updated for this message. Gas accounting is not exposed by
-        // the Midnight contract today; surface a non-zero placeholder so
-        // the relayer's queue metrics aren't divided by zero.
         Ok(TxOutcome {
             transaction_id: outcome.transaction_id,
             executed: outcome.executed,
@@ -176,10 +134,8 @@ impl Mailbox for MidnightMailbox {
         _message: &HyperlaneMessage,
         _metadata: &Metadata,
     ) -> ChainResult<TxCostEstimate> {
-        // Midnight fees are denominated in DUST and computed by the wallet
-        // at submission time. The relayer just needs a non-zero placeholder
-        // here; the submitter handles the real fee math. Same minimal
-        // pattern Aleo uses.
+        // Midnight fees are denominated in DUST and computed by the wallet at
+        // submission time. The relayer just needs a non-zero placeholder here.
         Ok(TxCostEstimate {
             gas_limit: U256::from(1_000_000_u32),
             gas_price: FixedPointNumber::from_str("1")
@@ -193,33 +149,15 @@ impl Mailbox for MidnightMailbox {
         _message: &HyperlaneMessage,
         _metadata: &Metadata,
     ) -> ChainResult<Vec<u8>> {
-        // Only used by the Lander submitter path. Midnight uses the Classic
-        // path (subprocess), so there's no on-chain calldata to surface
-        // here.
         Err(HyperlaneMidnightError::NotImplemented("process_calldata (Lander path)").into())
     }
 
     fn delivered_calldata(&self, _message_id: H256) -> ChainResult<Option<Vec<u8>>> {
-        // Same rationale as `process_calldata` — Lander-only.
         Ok(None)
     }
 }
 
-/// Parse a MessageIdMultisigIsmMetadata blob into the fields the Midnight
-/// `handle` circuit expects.
-///
-/// Layout (matches upstream `relayer/src/msg/metadata/multisig/base.rs`):
-///
-/// ```text
-/// [0..32]   merkle tree hook address
-/// [32..64]  root
-/// [64..68]  index (u32 big-endian)
-/// [68..]    signatures (65 bytes each, up to 16)
-/// ```
-///
-/// Signatures shorter than `MAX_SIGNATURES` slots are padded with zeroed
-/// 65-byte entries — the on-chain ISM ignores anything past the threshold
-/// and accepts dummy filler in the unused tail positions.
+// Layout: merkle_tree_hook (32) || root (32) || index (u32 BE, 4) || sigs (65 each, up to 16).
 fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
     if bytes.len() < METADATA_HEADER_LEN {
         return Err(HyperlaneMidnightError::Other(format!(
@@ -262,8 +200,6 @@ fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
         })
         .collect();
 
-    // Pad to MAX_SIGNATURES so the on-chain `Vector<16, Bytes<65>>` always
-    // gets a full payload. The contract ignores entries past the threshold.
     let padding = format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]));
     while signatures.len() < MAX_SIGNATURES {
         signatures.push(padding.clone());
@@ -284,42 +220,25 @@ mod tests {
     #[test]
     fn parse_metadata_extracts_fields() {
         let mut bytes = vec![0u8; METADATA_HEADER_LEN];
-        // merkle_tree_hook: 0xAB...AB
         for b in &mut bytes[0..32] {
             *b = 0xAB;
         }
-        // root: 0xCD...CD
         for b in &mut bytes[32..64] {
             *b = 0xCD;
         }
-        // index: 0x0000_002A (42 big-endian)
         bytes[64..68].copy_from_slice(&42u32.to_be_bytes());
-        // 2 signatures, each filled with a marker byte.
         for marker in [0x11u8, 0x22u8] {
             bytes.extend(std::iter::repeat_n(marker, SIGNATURE_LEN));
         }
 
-        let parsed = parse_metadata(&bytes).expect("parse should succeed");
-        assert_eq!(
-            parsed.merkle_tree_hook,
-            format!("0x{}", hex::encode([0xABu8; 32]))
-        );
+        let parsed = parse_metadata(&bytes).unwrap();
+        assert_eq!(parsed.merkle_tree_hook, format!("0x{}", hex::encode([0xABu8; 32])));
         assert_eq!(parsed.root, format!("0x{}", hex::encode([0xCDu8; 32])));
         assert_eq!(parsed.index, 42);
         assert_eq!(parsed.signatures.len(), MAX_SIGNATURES);
-        assert_eq!(
-            parsed.signatures[0],
-            format!("0x{}", hex::encode([0x11u8; SIGNATURE_LEN]))
-        );
-        assert_eq!(
-            parsed.signatures[1],
-            format!("0x{}", hex::encode([0x22u8; SIGNATURE_LEN]))
-        );
-        // Slot 2 onwards is zero-padding.
-        assert_eq!(
-            parsed.signatures[2],
-            format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]))
-        );
+        assert_eq!(parsed.signatures[0], format!("0x{}", hex::encode([0x11u8; SIGNATURE_LEN])));
+        assert_eq!(parsed.signatures[1], format!("0x{}", hex::encode([0x22u8; SIGNATURE_LEN])));
+        assert_eq!(parsed.signatures[2], format!("0x{}", hex::encode([0u8; SIGNATURE_LEN])));
     }
 
     #[test]

--- a/rust/main/chains/hyperlane-midnight/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-midnight/src/mailbox.rs
@@ -1,0 +1,356 @@
+//! Destination-side `Mailbox` implementation for Midnight.
+//!
+//! The relayer calls `process(message, metadata, ...)` once it has gathered a
+//! signed checkpoint quorum. This impl parses the canonical
+//! MessageIdMultisigIsmMetadata layout, packages the fields as JSON, and
+//! spawns the Midnight handle submitter as a subprocess. The submitter
+//! (TypeScript, in `equilibriumco/hyperlane-midnight`) generates the ZK
+//! proof and broadcasts the `handle` circuit call.
+
+use std::str::FromStr;
+
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    ChainCommunicationError, ChainResult, ContractLocator, FixedPointNumber, HyperlaneChain,
+    HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider, Mailbox, Metadata,
+    ReorgPeriod, TxCostEstimate, TxOutcome, H256, U256,
+};
+
+use crate::toolkit::{self, ToolkitContext, WireMetadata};
+use crate::{ConnectionConf, HyperlaneMidnightError, MidnightIndexerClient, MidnightProvider};
+
+/// Maximum signature slots in the on-chain `Vector<16, Bytes<65>>`. Mirrors
+/// `MAX_VALIDATORS` in the Compact contract.
+const MAX_SIGNATURES: usize = 16;
+/// Length of a single signature (`r || s || v`).
+const SIGNATURE_LEN: usize = 65;
+/// MessageIdMultisigIsmMetadata layout header length:
+/// `merkle_tree_hook (32) || root (32) || index (4)`.
+const METADATA_HEADER_LEN: usize = 32 + 32 + 4;
+
+/// Default proof-server endpoint used when the env override is unset. Keeps
+/// the devnet shape (see `hyperlane-midnight/devnet/src/config.ts`).
+const DEFAULT_PROOF_SERVER_URL: &str = "http://127.0.0.1:6300";
+/// Default Midnight network id when not overridden via env.
+const DEFAULT_NETWORK_ID: &str = "undeployed";
+
+/// Destination-side Mailbox.
+#[derive(Debug, Clone)]
+pub struct MidnightMailbox {
+    address: H256,
+    domain: HyperlaneDomain,
+    provider: MidnightProvider,
+    toolkit_ctx: ToolkitContext,
+}
+
+impl MidnightMailbox {
+    /// Build a new Mailbox bound to the given chain config and contract
+    /// locator. The provider exposes the indexer URL for `HyperlaneChain`
+    /// consumers; the toolkit context drives `process`.
+    pub fn new(locator: &ContractLocator<'_>, conf: &ConnectionConf) -> ChainResult<Self> {
+        let indexer = MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
+        let provider = MidnightProvider::new(locator.domain.clone(), indexer);
+
+        let binary_path = conf.toolkit_path.clone().unwrap_or_default();
+        let indexer_graphql_url = conf.indexer_graphql_url.to_string();
+        let indexer_ws_url = derive_ws_url(&conf.indexer_graphql_url);
+        let node_rpc_url = std::env::var("MIDNIGHT_NODE_RPC_URL").unwrap_or_default();
+        let proof_server_url = std::env::var("MIDNIGHT_PROOF_SERVER_URL")
+            .unwrap_or_else(|_| DEFAULT_PROOF_SERVER_URL.to_string());
+        let network_id =
+            std::env::var("MIDNIGHT_NETWORK_ID").unwrap_or_else(|_| DEFAULT_NETWORK_ID.to_string());
+
+        let toolkit_ctx = ToolkitContext {
+            binary_path,
+            indexer_graphql_url,
+            indexer_ws_url,
+            node_rpc_url,
+            proof_server_url,
+            network_id,
+        };
+
+        Ok(Self {
+            address: locator.address,
+            domain: locator.domain.clone(),
+            provider,
+            toolkit_ctx,
+        })
+    }
+}
+
+/// Convert the indexer's HTTP URL to a WebSocket URL using the same path
+/// convention midnight-indexer ships (`/graphql/ws` alongside `/graphql`).
+fn derive_ws_url(http: &url::Url) -> String {
+    let mut ws = http.clone();
+    let scheme = match http.scheme() {
+        "https" => "wss",
+        _ => "ws",
+    };
+    let _ = ws.set_scheme(scheme);
+    let path = ws.path().to_string();
+    if !path.ends_with("/ws") {
+        ws.set_path(&format!("{path}/ws"));
+    }
+    ws.to_string()
+}
+
+impl HyperlaneChain for MidnightMailbox {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.provider.clone())
+    }
+}
+
+impl HyperlaneContract for MidnightMailbox {
+    fn address(&self) -> H256 {
+        self.address
+    }
+}
+
+#[async_trait]
+impl Mailbox for MidnightMailbox {
+    /// Destination-side has no dispatch nonce to report. The relayer doesn't
+    /// rely on this value for inbound delivery; the proper outbound count
+    /// arrives with #9 + #16.
+    async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+        Ok(0)
+    }
+
+    async fn delivered(&self, id: H256) -> ChainResult<bool> {
+        toolkit::query_delivered(&self.toolkit_ctx, self.address, id).await
+    }
+
+    /// The WarpRoute is monolithic — the Mailbox, ISM, hook, and warp logic
+    /// all live in one contract, so the "default ISM" address is this
+    /// contract's own address.
+    async fn default_ism(&self) -> ChainResult<H256> {
+        Ok(self.address)
+    }
+
+    /// Same monolithic contract — every recipient routes through the same
+    /// embedded MessageIdMultisigIsm.
+    async fn recipient_ism(&self, _recipient: H256) -> ChainResult<H256> {
+        Ok(self.address)
+    }
+
+    async fn process(
+        &self,
+        message: &HyperlaneMessage,
+        metadata: &Metadata,
+        _tx_gas_limit: Option<U256>,
+    ) -> ChainResult<TxOutcome> {
+        let parsed = parse_metadata(metadata.as_ref())?;
+        let request = toolkit::build_request(
+            self.address,
+            &self.toolkit_ctx,
+            message,
+            parsed,
+            // The destination-side WarpRoute is user-facing. Contract
+            // recipients are out of scope until the warp route grows a
+            // routing layer; default to false so `sendUnshielded` lands as
+            // `UserAddress`.
+            false,
+        );
+
+        let outcome = toolkit::submit_handle(&self.toolkit_ctx, &request).await?;
+
+        // The submitter only returns success when the on-chain replay set
+        // was updated for this message. Gas accounting is not exposed by
+        // the Midnight contract today; surface a non-zero placeholder so
+        // the relayer's queue metrics aren't divided by zero.
+        Ok(TxOutcome {
+            transaction_id: outcome.transaction_id,
+            executed: outcome.executed,
+            gas_used: U256::from(1_u32),
+            gas_price: FixedPointNumber::from_str("1")
+                .map_err(|err| ChainCommunicationError::from_other_str(&err.to_string()))?,
+        })
+    }
+
+    async fn process_estimate_costs(
+        &self,
+        _message: &HyperlaneMessage,
+        _metadata: &Metadata,
+    ) -> ChainResult<TxCostEstimate> {
+        // Midnight fees are denominated in DUST and computed by the wallet
+        // at submission time. The relayer just needs a non-zero placeholder
+        // here; the submitter handles the real fee math. Same minimal
+        // pattern Aleo uses.
+        Ok(TxCostEstimate {
+            gas_limit: U256::from(1_000_000_u32),
+            gas_price: FixedPointNumber::from_str("1")
+                .map_err(|err| ChainCommunicationError::from_other_str(&err.to_string()))?,
+            l2_gas_limit: None,
+        })
+    }
+
+    async fn process_calldata(
+        &self,
+        _message: &HyperlaneMessage,
+        _metadata: &Metadata,
+    ) -> ChainResult<Vec<u8>> {
+        // Only used by the Lander submitter path. Midnight uses the Classic
+        // path (subprocess), so there's no on-chain calldata to surface
+        // here.
+        Err(HyperlaneMidnightError::NotImplemented("process_calldata (Lander path)").into())
+    }
+
+    fn delivered_calldata(&self, _message_id: H256) -> ChainResult<Option<Vec<u8>>> {
+        // Same rationale as `process_calldata` — Lander-only.
+        Ok(None)
+    }
+}
+
+/// Parse a MessageIdMultisigIsmMetadata blob into the fields the Midnight
+/// `handle` circuit expects.
+///
+/// Layout (matches upstream `relayer/src/msg/metadata/multisig/base.rs`):
+///
+/// ```text
+/// [0..32]   merkle tree hook address
+/// [32..64]  root
+/// [64..68]  index (u32 big-endian)
+/// [68..]    signatures (65 bytes each, up to 16)
+/// ```
+///
+/// Signatures shorter than `MAX_SIGNATURES` slots are padded with zeroed
+/// 65-byte entries — the on-chain ISM ignores anything past the threshold
+/// and accepts dummy filler in the unused tail positions.
+fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
+    if bytes.len() < METADATA_HEADER_LEN {
+        return Err(HyperlaneMidnightError::Other(format!(
+            "metadata too short: {} bytes (need at least {METADATA_HEADER_LEN})",
+            bytes.len()
+        ))
+        .into());
+    }
+
+    let sigs_blob = &bytes[METADATA_HEADER_LEN..];
+    if sigs_blob.len() % SIGNATURE_LEN != 0 {
+        return Err(HyperlaneMidnightError::Other(format!(
+            "metadata signature region {} bytes is not a multiple of {SIGNATURE_LEN}",
+            sigs_blob.len()
+        ))
+        .into());
+    }
+
+    let sig_count = sigs_blob.len() / SIGNATURE_LEN;
+    if sig_count > MAX_SIGNATURES {
+        return Err(HyperlaneMidnightError::Other(format!(
+            "metadata carries {sig_count} signatures, exceeds on-chain bound of {MAX_SIGNATURES}"
+        ))
+        .into());
+    }
+
+    let merkle_tree_hook = format!("0x{}", hex::encode(&bytes[0..32]));
+    let root = format!("0x{}", hex::encode(&bytes[32..64]));
+    let mut index_be = [0u8; 4];
+    index_be.copy_from_slice(&bytes[64..68]);
+    let index = u32::from_be_bytes(index_be);
+
+    let mut signatures: Vec<String> = (0..sig_count)
+        .map(|i| {
+            let start = i * SIGNATURE_LEN;
+            format!(
+                "0x{}",
+                hex::encode(&sigs_blob[start..start + SIGNATURE_LEN])
+            )
+        })
+        .collect();
+
+    // Pad to MAX_SIGNATURES so the on-chain `Vector<16, Bytes<65>>` always
+    // gets a full payload. The contract ignores entries past the threshold.
+    let padding = format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]));
+    while signatures.len() < MAX_SIGNATURES {
+        signatures.push(padding.clone());
+    }
+
+    Ok(WireMetadata {
+        merkle_tree_hook,
+        root,
+        index,
+        signatures,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_metadata_extracts_fields() {
+        let mut bytes = vec![0u8; METADATA_HEADER_LEN];
+        // merkle_tree_hook: 0xAB...AB
+        for b in &mut bytes[0..32] {
+            *b = 0xAB;
+        }
+        // root: 0xCD...CD
+        for b in &mut bytes[32..64] {
+            *b = 0xCD;
+        }
+        // index: 0x0000_002A (42 big-endian)
+        bytes[64..68].copy_from_slice(&42u32.to_be_bytes());
+        // 2 signatures, each filled with a marker byte.
+        for marker in [0x11u8, 0x22u8] {
+            bytes.extend(std::iter::repeat_n(marker, SIGNATURE_LEN));
+        }
+
+        let parsed = parse_metadata(&bytes).expect("parse should succeed");
+        assert_eq!(
+            parsed.merkle_tree_hook,
+            format!("0x{}", hex::encode([0xABu8; 32]))
+        );
+        assert_eq!(parsed.root, format!("0x{}", hex::encode([0xCDu8; 32])));
+        assert_eq!(parsed.index, 42);
+        assert_eq!(parsed.signatures.len(), MAX_SIGNATURES);
+        assert_eq!(
+            parsed.signatures[0],
+            format!("0x{}", hex::encode([0x11u8; SIGNATURE_LEN]))
+        );
+        assert_eq!(
+            parsed.signatures[1],
+            format!("0x{}", hex::encode([0x22u8; SIGNATURE_LEN]))
+        );
+        // Slot 2 onwards is zero-padding.
+        assert_eq!(
+            parsed.signatures[2],
+            format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]))
+        );
+    }
+
+    #[test]
+    fn parse_metadata_rejects_short_input() {
+        let bytes = vec![0u8; METADATA_HEADER_LEN - 1];
+        assert!(parse_metadata(&bytes).is_err());
+    }
+
+    #[test]
+    fn parse_metadata_rejects_unaligned_signatures() {
+        let mut bytes = vec![0u8; METADATA_HEADER_LEN];
+        bytes.extend(std::iter::repeat_n(0u8, SIGNATURE_LEN - 1));
+        assert!(parse_metadata(&bytes).is_err());
+    }
+
+    #[test]
+    fn parse_metadata_rejects_too_many_signatures() {
+        let mut bytes = vec![0u8; METADATA_HEADER_LEN];
+        bytes.extend(std::iter::repeat_n(0u8, (MAX_SIGNATURES + 1) * SIGNATURE_LEN));
+        assert!(parse_metadata(&bytes).is_err());
+    }
+
+    #[test]
+    fn derive_ws_url_appends_ws_path_and_swaps_scheme() {
+        let http = url::Url::parse("http://indexer.local/api/v3/graphql").unwrap();
+        assert_eq!(
+            derive_ws_url(&http),
+            "ws://indexer.local/api/v3/graphql/ws"
+        );
+
+        let https = url::Url::parse("https://indexer.example/graphql").unwrap();
+        assert_eq!(derive_ws_url(&https), "wss://indexer.example/graphql/ws");
+    }
+}

--- a/rust/main/chains/hyperlane-midnight/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-midnight/src/mailbox.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, ContractLocator, FixedPointNumber, HyperlaneChain,
     HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider, Mailbox, Metadata,
-    ReorgPeriod, TxCostEstimate, TxOutcome, H256, U256,
+    ReorgPeriod, TxCostEstimate, TxOutcome, H160, H256, U256,
 };
 
 use crate::toolkit::{self, ToolkitContext, WireMetadata};
@@ -25,6 +25,11 @@ pub struct MidnightMailbox {
     domain: HyperlaneDomain,
     provider: MidnightProvider,
     toolkit_ctx: ToolkitContext,
+    /// Validators registered on the destination contract, in the order the
+    /// on-chain `validators` vector was set at construction. Used to sort
+    /// signatures by validator-set index before handing metadata to the
+    /// submitter so the on-chain two-pointer multisig walk accepts them.
+    validators: Vec<H160>,
 }
 
 impl MidnightMailbox {
@@ -56,6 +61,7 @@ impl MidnightMailbox {
             domain: locator.domain.clone(),
             provider,
             toolkit_ctx,
+            validators: conf.validators.clone(),
         })
     }
 }
@@ -114,7 +120,19 @@ impl Mailbox for MidnightMailbox {
         metadata: &Metadata,
         _tx_gas_limit: Option<U256>,
     ) -> ChainResult<TxOutcome> {
-        let parsed = parse_metadata(metadata.as_ref())?;
+        let mut parsed = parse_metadata(metadata.as_ref())?;
+
+        // The on-chain MessageIdMultisigIsm requires signatures in
+        // validator-set-index order (two-pointer match). The relayer's
+        // metadata builder concatenates signatures in fetch-completion
+        // order, not validator-index order (only Aleo gets a special-case
+        // sort in `hyperlane-base/src/types/multisig.rs`). Sort here so the
+        // Midnight contract accepts the metadata. Skips when no validator
+        // list is configured (preserves cross-boundary test behaviour).
+        if !self.validators.is_empty() {
+            sort_signatures_by_validator_index(message, &mut parsed, &self.validators)?;
+        }
+
         let request =
             toolkit::build_request(self.address, &self.toolkit_ctx, message, parsed, false);
 
@@ -213,6 +231,114 @@ fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
     })
 }
 
+/// Reorder the real signatures in `metadata` by their signer's index in
+/// `validators`, then re-pad to `MAX_SIGNATURES` with zero signatures.
+/// Errors if any signature recovers to an address not present in
+/// `validators` — that indicates either a malformed validator config or a
+/// genuinely invalid signature; either way the on-chain ISM would reject
+/// the call so failing fast here surfaces the issue with a clearer error
+/// than a Compact `assert` revert.
+fn sort_signatures_by_validator_index(
+    message: &HyperlaneMessage,
+    metadata: &mut WireMetadata,
+    validators: &[H160],
+) -> ChainResult<()> {
+    let zero_sig_hex = format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]));
+    let mut reals: Vec<String> = metadata
+        .signatures
+        .iter()
+        .filter(|s| **s != zero_sig_hex)
+        .cloned()
+        .collect();
+    if reals.is_empty() {
+        return Ok(());
+    }
+
+    let inner_hash = compute_checkpoint_inner_hash(message, metadata)?;
+
+    let mut indexed: Vec<(usize, String)> = Vec::with_capacity(reals.len());
+    for sig_hex in reals.drain(..) {
+        let bytes = hex::decode(sig_hex.trim_start_matches("0x")).map_err(|e| {
+            HyperlaneMidnightError::Other(format!("signature hex decode: {e}"))
+        })?;
+        if bytes.len() != SIGNATURE_LEN {
+            return Err(HyperlaneMidnightError::Other(format!(
+                "signature must be {SIGNATURE_LEN} bytes, got {}",
+                bytes.len()
+            ))
+            .into());
+        }
+        let signer = recover_signer(&inner_hash, &bytes)?;
+        let idx = validators.iter().position(|v| *v == signer).ok_or_else(|| {
+            HyperlaneMidnightError::Other(format!(
+                "signer {signer:?} not in configured validator set"
+            ))
+        })?;
+        indexed.push((idx, sig_hex));
+    }
+    indexed.sort_by_key(|(i, _)| *i);
+
+    metadata.signatures = indexed.into_iter().map(|(_, s)| s).collect();
+    while metadata.signatures.len() < MAX_SIGNATURES {
+        metadata.signatures.push(zero_sig_hex.clone());
+    }
+    Ok(())
+}
+
+/// keccak(domainHash || root || index_be || messageId), where
+/// domainHash = keccak(origin_domain_be32 || merkle_tree_hook || "HYPERLANE").
+/// Matches the on-chain Midnight MessageIdMultisigIsm digest pre-EIP-191
+/// (validators sign the EIP-191 wrap of this; ecrecover with
+/// RecoveryMessage::Data applies the same wrap).
+fn compute_checkpoint_inner_hash(
+    message: &HyperlaneMessage,
+    metadata: &WireMetadata,
+) -> ChainResult<[u8; 32]> {
+    let merkle_tree_hook = decode_hex_32(&metadata.merkle_tree_hook)?;
+    let root = decode_hex_32(&metadata.root)?;
+    let message_id_h256: H256 = message.id();
+    let message_id: [u8; 32] = message_id_h256.into();
+
+    let mut buf = Vec::with_capacity(4 + 32 + 9);
+    buf.extend_from_slice(&message.origin.to_be_bytes());
+    buf.extend_from_slice(&merkle_tree_hook);
+    buf.extend_from_slice(b"HYPERLANE");
+    let domain_hash = ethers::utils::keccak256(&buf);
+
+    let mut buf = Vec::with_capacity(32 + 32 + 4 + 32);
+    buf.extend_from_slice(&domain_hash);
+    buf.extend_from_slice(&root);
+    buf.extend_from_slice(&metadata.index.to_be_bytes());
+    buf.extend_from_slice(&message_id);
+    Ok(ethers::utils::keccak256(&buf))
+}
+
+fn decode_hex_32(s: &str) -> ChainResult<[u8; 32]> {
+    let bytes = hex::decode(s.trim_start_matches("0x"))
+        .map_err(|e| HyperlaneMidnightError::Other(format!("hex decode: {e}")))?;
+    if bytes.len() != 32 {
+        return Err(HyperlaneMidnightError::Other(format!(
+            "expected 32 bytes, got {}",
+            bytes.len()
+        ))
+        .into());
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn recover_signer(inner_hash: &[u8; 32], sig_bytes: &[u8]) -> ChainResult<H160> {
+    let sig = ethers::types::Signature::try_from(sig_bytes)
+        .map_err(|e| HyperlaneMidnightError::Other(format!("malformed signature: {e}")))?;
+    let recovered = sig
+        .recover(inner_hash.to_vec())
+        .map_err(|e| HyperlaneMidnightError::Other(format!("ecrecover failed: {e}")))?;
+    // ethers::types::H160 and hyperlane_core::H160 are both 20-byte primitive
+    // hashes but distinct types; convert through the inner byte array.
+    Ok(H160::from(recovered.0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,5 +397,101 @@ mod tests {
 
         let https = url::Url::parse("https://indexer.example/graphql").unwrap();
         assert_eq!(derive_ws_url(&https), "wss://indexer.example/graphql/ws");
+    }
+
+    #[tokio::test]
+    async fn sort_signatures_reorders_by_validator_index_and_repads() {
+        use ethers::signers::{LocalWallet, Signer};
+
+        let k0: LocalWallet =
+            "1111111111111111111111111111111111111111111111111111111111111111"
+                .parse()
+                .unwrap();
+        let k1: LocalWallet =
+            "2222222222222222222222222222222222222222222222222222222222222222"
+                .parse()
+                .unwrap();
+        let v0 = H160::from(k0.address().0);
+        let v1 = H160::from(k1.address().0);
+        let validators = vec![v0, v1];
+
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce: 0,
+            origin: 31337,
+            sender: H256::repeat_byte(0x33),
+            destination: 1234,
+            recipient: H256::repeat_byte(0x44),
+            body: vec![0u8; 64],
+        };
+        let mut metadata = WireMetadata {
+            merkle_tree_hook: format!("0x{}", hex::encode([0xABu8; 32])),
+            root: format!("0x{}", hex::encode([0xCDu8; 32])),
+            index: 7,
+            signatures: vec![],
+        };
+
+        let inner = compute_checkpoint_inner_hash(&message, &metadata).unwrap();
+        let sig0 = k0.sign_message(&inner[..]).await.unwrap();
+        let sig1 = k1.sign_message(&inner[..]).await.unwrap();
+        let sig0_hex = format!("0x{}", hex::encode(<[u8; 65]>::from(sig0)));
+        let sig1_hex = format!("0x{}", hex::encode(<[u8; 65]>::from(sig1)));
+        let zero_hex = format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]));
+
+        // Insert signatures in REVERSE validator-index order, plus padding.
+        metadata.signatures = vec![sig1_hex.clone(), sig0_hex.clone()];
+        while metadata.signatures.len() < MAX_SIGNATURES {
+            metadata.signatures.push(zero_hex.clone());
+        }
+
+        sort_signatures_by_validator_index(&message, &mut metadata, &validators).unwrap();
+
+        assert_eq!(metadata.signatures.len(), MAX_SIGNATURES);
+        assert_eq!(metadata.signatures[0], sig0_hex);
+        assert_eq!(metadata.signatures[1], sig1_hex);
+        for s in metadata.signatures.iter().skip(2) {
+            assert_eq!(*s, zero_hex);
+        }
+    }
+
+    #[tokio::test]
+    async fn sort_signatures_errors_on_unknown_signer() {
+        use ethers::signers::{LocalWallet, Signer};
+
+        let k_known: LocalWallet =
+            "1111111111111111111111111111111111111111111111111111111111111111"
+                .parse()
+                .unwrap();
+        let k_rogue: LocalWallet =
+            "9999999999999999999999999999999999999999999999999999999999999999"
+                .parse()
+                .unwrap();
+        // Validator set knows only k_known; k_rogue must be rejected.
+        let validators = vec![H160::from(k_known.address().0)];
+
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce: 0,
+            origin: 31337,
+            sender: H256::repeat_byte(0x33),
+            destination: 1234,
+            recipient: H256::repeat_byte(0x44),
+            body: vec![0u8; 64],
+        };
+        let mut metadata = WireMetadata {
+            merkle_tree_hook: format!("0x{}", hex::encode([0xABu8; 32])),
+            root: format!("0x{}", hex::encode([0xCDu8; 32])),
+            index: 7,
+            signatures: vec![],
+        };
+        let inner = compute_checkpoint_inner_hash(&message, &metadata).unwrap();
+        let sig_rogue = k_rogue.sign_message(&inner[..]).await.unwrap();
+        let zero_hex = format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]));
+        metadata.signatures = vec![format!("0x{}", hex::encode(<[u8; 65]>::from(sig_rogue)))];
+        while metadata.signatures.len() < MAX_SIGNATURES {
+            metadata.signatures.push(zero_hex.clone());
+        }
+
+        assert!(sort_signatures_by_validator_index(&message, &mut metadata, &validators).is_err());
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/provider.rs
+++ b/rust/main/chains/hyperlane-midnight/src/provider.rs
@@ -1,10 +1,3 @@
-//! Minimal `HyperlaneProvider` implementation for Midnight.
-//!
-//! The destination-side Mailbox uses this only to satisfy `HyperlaneChain`'s
-//! `provider()` accessor. Block- and txn-level queries return
-//! `NotImplemented` until the full Midnight provider lands with issue #14 /
-//! #16.
-
 use async_trait::async_trait;
 
 use hyperlane_core::{
@@ -14,8 +7,7 @@ use hyperlane_core::{
 
 use crate::{HyperlaneMidnightError, MidnightIndexerClient};
 
-/// Skeleton provider. Carries enough to serve `HyperlaneChain` and a single
-/// indexer ping; anything else returns `NotImplemented` until #14 / #16.
+/// Skeleton provider.
 #[derive(Debug, Clone)]
 pub struct MidnightProvider {
     domain: HyperlaneDomain,
@@ -23,7 +15,7 @@ pub struct MidnightProvider {
 }
 
 impl MidnightProvider {
-    /// Build a new provider with the given chain domain and indexer client.
+    /// Build a new provider.
     pub fn new(domain: HyperlaneDomain, indexer: MidnightIndexerClient) -> Self {
         Self { domain, indexer }
     }
@@ -50,18 +42,10 @@ impl HyperlaneProvider for MidnightProvider {
     }
 
     async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
-        // The relayer's `pending_message` state machine drops inbound messages
-        // when this returns `false` (see `agents/relayer/src/msg/pending_message.rs`
-        // — `is_recipient_contract` gate). For the monolithic WarpRoute design
-        // every Hyperlane-routable recipient on Midnight IS the WarpRoute
-        // contract itself, so the safe answer here is `true`. The on-circuit
-        // `isContractRecipient` flag — whether `sendUnshielded` ultimately
-        // pays out to a `ContractAddress` vs `UserAddress` — is a separate
-        // decision threaded through `Mailbox::process` at submission time.
-        //
-        // If/when the design grows non-WarpRoute recipients on Midnight, this
-        // must query the indexer for actual contract-vs-EOA classification
-        // (work scoped to issue #14).
+        // Returning false makes `pending_message` drop every inbound message
+        // at the `is_recipient_contract` gate. Every routable recipient on
+        // Midnight is the monolithic WarpRoute contract, so `true` is correct
+        // until non-WarpRoute recipients exist.
         Ok(true)
     }
 
@@ -70,13 +54,7 @@ impl HyperlaneProvider for MidnightProvider {
     }
 
     async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
-        // Best-effort liveness: report the latest known indexer height as
-        // chain progress when available, otherwise `None`.
-        match self.indexer.latest_block_height().await {
-            Ok(Some(_height)) => Ok(None),
-            Ok(None) => Ok(None),
-            // Indexer ping is non-fatal here; treat as "no metrics yet".
-            Err(_) => Ok(None),
-        }
+        let _ = self.indexer.latest_block_height().await;
+        Ok(None)
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/provider.rs
+++ b/rust/main/chains/hyperlane-midnight/src/provider.rs
@@ -1,0 +1,73 @@
+//! Minimal `HyperlaneProvider` implementation for Midnight.
+//!
+//! The destination-side Mailbox uses this only to satisfy `HyperlaneChain`'s
+//! `provider()` accessor. Block- and txn-level queries return
+//! `NotImplemented` until the full Midnight provider lands with issue #14 /
+//! #16.
+
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    BlockInfo, ChainInfo, ChainResult, HyperlaneChain, HyperlaneDomain, HyperlaneProvider, TxnInfo,
+    H256, H512, U256,
+};
+
+use crate::{HyperlaneMidnightError, MidnightIndexerClient};
+
+/// Skeleton provider. Carries enough to serve `HyperlaneChain` and a single
+/// indexer ping; anything else returns `NotImplemented` until #14 / #16.
+#[derive(Debug, Clone)]
+pub struct MidnightProvider {
+    domain: HyperlaneDomain,
+    indexer: MidnightIndexerClient,
+}
+
+impl MidnightProvider {
+    /// Build a new provider with the given chain domain and indexer client.
+    pub fn new(domain: HyperlaneDomain, indexer: MidnightIndexerClient) -> Self {
+        Self { domain, indexer }
+    }
+}
+
+impl HyperlaneChain for MidnightProvider {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.clone())
+    }
+}
+
+#[async_trait]
+impl HyperlaneProvider for MidnightProvider {
+    async fn get_block_by_height(&self, _height: u64) -> ChainResult<BlockInfo> {
+        Err(HyperlaneMidnightError::NotImplemented("get_block_by_height").into())
+    }
+
+    async fn get_txn_by_hash(&self, _hash: &H512) -> ChainResult<TxnInfo> {
+        Err(HyperlaneMidnightError::NotImplemented("get_txn_by_hash").into())
+    }
+
+    async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
+        // Until the indexer client exposes contract metadata (issue #14), all
+        // recipients are treated as user addresses for routing. The Mailbox's
+        // `isContractRecipient` flag is supplied separately at process time.
+        Ok(false)
+    }
+
+    async fn get_balance(&self, _address: String) -> ChainResult<U256> {
+        Err(HyperlaneMidnightError::NotImplemented("get_balance").into())
+    }
+
+    async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
+        // Best-effort liveness: report the latest known indexer height as
+        // chain progress when available, otherwise `None`.
+        match self.indexer.latest_block_height().await {
+            Ok(Some(_height)) => Ok(None),
+            Ok(None) => Ok(None),
+            // Indexer ping is non-fatal here; treat as "no metrics yet".
+            Err(_) => Ok(None),
+        }
+    }
+}

--- a/rust/main/chains/hyperlane-midnight/src/provider.rs
+++ b/rust/main/chains/hyperlane-midnight/src/provider.rs
@@ -50,10 +50,19 @@ impl HyperlaneProvider for MidnightProvider {
     }
 
     async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
-        // Until the indexer client exposes contract metadata (issue #14), all
-        // recipients are treated as user addresses for routing. The Mailbox's
-        // `isContractRecipient` flag is supplied separately at process time.
-        Ok(false)
+        // The relayer's `pending_message` state machine drops inbound messages
+        // when this returns `false` (see `agents/relayer/src/msg/pending_message.rs`
+        // — `is_recipient_contract` gate). For the monolithic WarpRoute design
+        // every Hyperlane-routable recipient on Midnight IS the WarpRoute
+        // contract itself, so the safe answer here is `true`. The on-circuit
+        // `isContractRecipient` flag — whether `sendUnshielded` ultimately
+        // pays out to a `ContractAddress` vs `UserAddress` — is a separate
+        // decision threaded through `Mailbox::process` at submission time.
+        //
+        // If/when the design grows non-WarpRoute recipients on Midnight, this
+        // must query the indexer for actual contract-vs-EOA classification
+        // (work scoped to issue #14).
+        Ok(true)
     }
 
     async fn get_balance(&self, _address: String) -> ChainResult<U256> {

--- a/rust/main/chains/hyperlane-midnight/src/signer.rs
+++ b/rust/main/chains/hyperlane-midnight/src/signer.rs
@@ -1,13 +1,8 @@
 use hyperlane_core::H256;
 
-/// Placeholder signer for Midnight.
-///
-/// Real signing is performed by the Midnight handle-submitter subprocess
-/// (see `ConnectionConf::toolkit_path` and the `relayer/` workspace in
-/// `equilibriumco/hyperlane-midnight`). This struct exists only to satisfy
-/// the `ChainSigner` + `BuildableWithSignerConf` trait surface in
-/// `hyperlane-base`. The submitter reads the relayer wallet seed from the
-/// `MIDNIGHT_RELAYER_SEED` env var.
+/// Placeholder signer. Real signing happens inside the submitter
+/// subprocess; this exists only to satisfy `ChainSigner` +
+/// `BuildableWithSignerConf` in `hyperlane-base`.
 #[derive(Clone, Debug, Default)]
 pub struct MidnightSigner {
     address: String,
@@ -15,18 +10,17 @@ pub struct MidnightSigner {
 }
 
 impl MidnightSigner {
-    /// Construct a placeholder signer. The real signer lives inside the
-    /// submitter subprocess; the agent-side struct stays empty.
+    /// Construct a placeholder signer.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Returns the configured address (always empty for the placeholder).
+    /// Returns the configured address.
     pub fn address(&self) -> &str {
         &self.address
     }
 
-    /// Returns the configured address as `H256` (always zero for the placeholder).
+    /// Returns the configured address as `H256`.
     pub fn address_h256(&self) -> H256 {
         self.address_h256
     }

--- a/rust/main/chains/hyperlane-midnight/src/signer.rs
+++ b/rust/main/chains/hyperlane-midnight/src/signer.rs
@@ -2,10 +2,12 @@ use hyperlane_core::H256;
 
 /// Placeholder signer for Midnight.
 ///
-/// Real signing is performed by the `midnight-node-toolkit` subprocess
-/// (issue #20). This struct exists at scaffolding time only to satisfy the
-/// `ChainSigner` + `BuildableWithSignerConf` trait surface in
-/// `hyperlane-base`.
+/// Real signing is performed by the Midnight handle-submitter subprocess
+/// (see `ConnectionConf::toolkit_path` and the `relayer/` workspace in
+/// `equilibriumco/hyperlane-midnight`). This struct exists only to satisfy
+/// the `ChainSigner` + `BuildableWithSignerConf` trait surface in
+/// `hyperlane-base`. The submitter reads the relayer wallet seed from the
+/// `MIDNIGHT_RELAYER_SEED` env var.
 #[derive(Clone, Debug, Default)]
 pub struct MidnightSigner {
     address: String,
@@ -13,18 +15,18 @@ pub struct MidnightSigner {
 }
 
 impl MidnightSigner {
-    /// Construct a placeholder signer. At #13 the address is empty / zero;
-    /// #20 will populate these from the toolkit.
+    /// Construct a placeholder signer. The real signer lives inside the
+    /// submitter subprocess; the agent-side struct stays empty.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Returns the configured address (empty at #13).
+    /// Returns the configured address (always empty for the placeholder).
     pub fn address(&self) -> &str {
         &self.address
     }
 
-    /// Returns the configured address as `H256` (zero at #13).
+    /// Returns the configured address as `H256` (always zero for the placeholder).
     pub fn address_h256(&self) -> H256 {
         self.address_h256
     }
@@ -41,7 +43,7 @@ mod tests {
     fn config_constructs() {
         let conf = ConnectionConf::new(
             Url::parse("http://localhost:8080/graphql").unwrap(),
-            Some("/usr/local/bin/midnight-node-toolkit".to_string()),
+            Some("/srv/hyperlane/relayer/dist/submit-handle.js".to_string()),
         );
         assert_eq!(
             conf.indexer_graphql_url.as_str(),

--- a/rust/main/chains/hyperlane-midnight/src/stubs.rs
+++ b/rust/main/chains/hyperlane-midnight/src/stubs.rs
@@ -1,0 +1,170 @@
+//! No-op stub implementations for traits the relayer requires but Midnight
+//! does not yet exercise.
+//!
+//! The relayer's `OriginFactory::create` requires every chain in
+//! `HYP_RELAYCHAINS` to satisfy origin-side traits (ValidatorAnnounce + three
+//! `SequenceAwareIndexer`s), regardless of whether messages are ever
+//! dispatched FROM that chain. For inbound-only Midnight today, none of these
+//! are exercised — but if any one fails, the chain drops out of the
+//! `origins` map and the relayer can't wire up destination delivery either
+//! (see `relayer::run` — destination message processors look up their DB by
+//! `origins.get(dest_domain)`).
+//!
+//! These stubs let midnight build as origin so destination delivery works.
+//! They will be replaced by real impls under:
+//!   - #33  ValidatorAnnounce agent-side trait
+//!   - #15  Validator: Merkle tree indexer
+//!   - #16  Message dispatch indexer + delivery indexer
+//!   - #19  Relayer: IGP payment indexer
+//!
+//! All depend on #14 (Midnight indexer client) for chain-state reads.
+
+use std::ops::RangeInclusive;
+
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    Announcement, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+    HyperlaneProvider, Indexed, Indexer, InterchainGasPayment, LogMeta, MerkleTreeInsertion,
+    SequenceAwareIndexer, SignedType, TxOutcome, H256, H512, U256,
+};
+use hyperlane_core::ValidatorAnnounce;
+
+use crate::MidnightProvider;
+
+/// Stub `ValidatorAnnounce` — Midnight never announces or queries storage
+/// locations through the agent-side trait today. Replaced by #33.
+#[derive(Debug)]
+pub struct MidnightValidatorAnnounceStub {
+    address: H256,
+    domain: HyperlaneDomain,
+    provider: MidnightProvider,
+}
+
+impl MidnightValidatorAnnounceStub {
+    /// Construct a new stub.
+    pub fn new(address: H256, domain: HyperlaneDomain, provider: MidnightProvider) -> Self {
+        Self {
+            address,
+            domain,
+            provider,
+        }
+    }
+}
+
+impl HyperlaneChain for MidnightValidatorAnnounceStub {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.provider.clone())
+    }
+}
+
+impl HyperlaneContract for MidnightValidatorAnnounceStub {
+    fn address(&self) -> H256 {
+        self.address
+    }
+}
+
+#[async_trait]
+impl ValidatorAnnounce for MidnightValidatorAnnounceStub {
+    async fn get_announced_storage_locations(
+        &self,
+        validators: &[H256],
+    ) -> ChainResult<Vec<Vec<String>>> {
+        // Return one empty list per validator — the relayer treats this as
+        // "no announcement on file" and skips that validator at metadata
+        // build time, which is correct: midnight-as-origin signing isn't
+        // wired up yet.
+        Ok(validators.iter().map(|_| Vec::new()).collect())
+    }
+
+    async fn announce(&self, _announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
+        // Validators on midnight don't announce via this code path (the
+        // contract is called directly from outside the agent for now). Any
+        // caller reaching here on midnight is a bug.
+        Err(hyperlane_core::ChainCommunicationError::CustomError(
+            "midnight: ValidatorAnnounce::announce is not implemented (see #33)".to_string(),
+        ))
+    }
+
+    async fn announce_tokens_needed(
+        &self,
+        _announcement: SignedType<Announcement>,
+        _chain_signer: H256,
+    ) -> Option<U256> {
+        None
+    }
+}
+
+/// Generic stub `SequenceAwareIndexer` used for all three origin-side
+/// indexers (dispatch / merkle / IGP). Returns no events and zero block
+/// height — safe because the relayer never has work to do on midnight
+/// outbound today. Replaced by #15, #16, #19.
+#[derive(Debug)]
+pub struct MidnightStubIndexer<T> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Default for MidnightStubIndexer<T> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> MidnightStubIndexer<T> {
+    /// Construct a new stub indexer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl<T> Indexer<T> for MidnightStubIndexer<T>
+where
+    T: Send + Sync + std::fmt::Debug + 'static,
+{
+    async fn fetch_logs_in_range(
+        &self,
+        _range: RangeInclusive<u32>,
+    ) -> ChainResult<Vec<(Indexed<T>, LogMeta)>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+        Ok(0)
+    }
+
+    async fn fetch_logs_by_tx_hash(
+        &self,
+        _tx_hash: H512,
+    ) -> ChainResult<Vec<(Indexed<T>, LogMeta)>> {
+        Ok(Vec::new())
+    }
+}
+
+#[async_trait]
+impl<T> SequenceAwareIndexer<T> for MidnightStubIndexer<T>
+where
+    T: Send + Sync + std::fmt::Debug + 'static,
+{
+    async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
+        // (None, 0) signals "no known sequence yet, chain at block 0" — the
+        // cursor stays parked and never advances. The relayer never expects
+        // to deliver from this chain anyway.
+        Ok((None, 0))
+    }
+}
+
+/// Type-aliased flavors for the three concrete `T`s the relayer instantiates.
+/// These exist purely so `chains.rs` can read like `MidnightMessageIndexer::new()`
+/// instead of spelling out the generic.
+pub type MidnightMessageIndexerStub = MidnightStubIndexer<hyperlane_core::HyperlaneMessage>;
+/// Stub for merkle tree insertion indexing.
+pub type MidnightMerkleTreeIndexerStub = MidnightStubIndexer<MerkleTreeInsertion>;
+/// Stub for IGP payment indexing.
+pub type MidnightIgpIndexerStub = MidnightStubIndexer<InterchainGasPayment>;

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -8,14 +8,24 @@
 //! captured into the error variants so operators see what failed.
 
 use std::process::Stdio;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 
 use hyperlane_core::{ChainResult, HyperlaneMessage, H256, H512};
 
 use crate::HyperlaneMidnightError;
+
+/// Wall-clock cap on a single `submit` invocation. Generous so a busy ZK
+/// proof server has headroom; tight enough that a wedged child does not
+/// block the relayer worker future forever.
+const SUBMIT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Wall-clock cap on a single `isDelivered` query. No proof work — just
+/// indexer fetch + ledger decode — so much tighter than `SUBMIT_TIMEOUT`.
+const DELIVERED_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// JSON payload written to the submitter's stdin.
 ///
@@ -159,59 +169,7 @@ pub async fn submit_handle(
     ctx: &ToolkitContext,
     request: &SubmitRequest<'_>,
 ) -> ChainResult<ToolkitOutcome> {
-    if ctx.binary_path.is_empty() {
-        return Err(HyperlaneMidnightError::MissingSubmitterPath.into());
-    }
-
-    let payload = serde_json::to_vec(request).map_err(HyperlaneMidnightError::from)?;
-
-    let mut child = Command::new(&ctx.binary_path)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
-            path: ctx.binary_path.clone(),
-            source,
-        })?;
-
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(&payload)
-            .await
-            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
-                path: ctx.binary_path.clone(),
-                source,
-            })?;
-        stdin
-            .shutdown()
-            .await
-            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
-                path: ctx.binary_path.clone(),
-                source,
-            })?;
-    }
-
-    let output =
-        child
-            .wait_with_output()
-            .await
-            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
-                path: ctx.binary_path.clone(),
-                source,
-            })?;
-
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    if !output.status.success() {
-        return Err(HyperlaneMidnightError::SubmitterFailed {
-            status: output.status.code().unwrap_or(-1),
-            stderr,
-        }
-        .into());
-    }
-
-    let raw = String::from_utf8_lossy(&output.stdout).to_string();
+    let raw = run_submitter(ctx, request, SUBMIT_TIMEOUT).await?;
     let response: SubmitResponse =
         serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
             message: err.to_string(),
@@ -312,10 +270,6 @@ pub async fn query_delivered(
     contract_address: H256,
     message_id: H256,
 ) -> ChainResult<bool> {
-    if ctx.binary_path.is_empty() {
-        return Err(HyperlaneMidnightError::MissingSubmitterPath.into());
-    }
-
     let request = IsDeliveredRequest {
         op: "isDelivered",
         contract_address: format!("0x{contract_address:x}"),
@@ -324,12 +278,56 @@ pub async fn query_delivered(
         network_id: ctx.network_id.clone(),
         message_id: format!("0x{message_id:x}"),
     };
-    let payload = serde_json::to_vec(&request).map_err(HyperlaneMidnightError::from)?;
 
-    let mut child = Command::new(&ctx.binary_path)
+    let raw = run_submitter(ctx, &request, DELIVERED_TIMEOUT).await?;
+    let response: IsDeliveredResponse =
+        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+            message: err.to_string(),
+            raw: truncate(&raw, 1024),
+        })?;
+
+    if let Some(error) = response.error {
+        return Err(HyperlaneMidnightError::SubmitterReported {
+            kind: error.kind,
+            message: error.message,
+        }
+        .into());
+    }
+
+    response
+        .delivered
+        .ok_or_else(|| HyperlaneMidnightError::SubmitterMalformed {
+            message: "missing `delivered` boolean in response".to_string(),
+            raw: truncate(&raw, 1024),
+        })
+        .map_err(Into::into)
+}
+
+/// Spawn the submitter binary, write `request` as JSON to stdin, wait up
+/// to `timeout` for the child to exit, and return its stdout as a string.
+///
+/// The child is spawned with `kill_on_drop(true)` so that if the calling
+/// future is cancelled (relayer shutdown, timeout, parent task drop) the
+/// Node process is reaped instead of leaked. On a timeout elapse the
+/// `Child` handle goes out of scope mid-await and SIGKILL is delivered;
+/// the error surfaces as `SubmitterTimeout` so callers can map it onto a
+/// dedicated retry classification.
+async fn run_submitter<R: Serialize>(
+    ctx: &ToolkitContext,
+    request: &R,
+    timeout: Duration,
+) -> ChainResult<String> {
+    if ctx.binary_path.is_empty() {
+        return Err(HyperlaneMidnightError::MissingSubmitterPath.into());
+    }
+
+    let payload = serde_json::to_vec(request).map_err(HyperlaneMidnightError::from)?;
+
+    let mut child: Child = Command::new(&ctx.binary_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
             path: ctx.binary_path.clone(),
@@ -353,14 +351,24 @@ pub async fn query_delivered(
             })?;
     }
 
-    let output =
-        child
-            .wait_with_output()
-            .await
-            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(source)) => {
+            return Err(HyperlaneMidnightError::SubmitterSpawn {
                 path: ctx.binary_path.clone(),
                 source,
-            })?;
+            }
+            .into());
+        }
+        Err(_elapsed) => {
+            // `child` dropped here → kill_on_drop(true) SIGKILLs the Node
+            // process before we return.
+            return Err(HyperlaneMidnightError::SubmitterTimeout {
+                elapsed_secs: timeout.as_secs(),
+            }
+            .into());
+        }
+    };
 
     if !output.status.success() {
         return Err(HyperlaneMidnightError::SubmitterFailed {
@@ -370,28 +378,7 @@ pub async fn query_delivered(
         .into());
     }
 
-    let raw = String::from_utf8_lossy(&output.stdout).to_string();
-    let response: IsDeliveredResponse =
-        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
-            message: err.to_string(),
-            raw: truncate(&raw, 1024),
-        })?;
-
-    if let Some(error) = response.error {
-        return Err(HyperlaneMidnightError::SubmitterReported {
-            kind: error.kind,
-            message: error.message,
-        }
-        .into());
-    }
-
-    response
-        .delivered
-        .ok_or_else(|| HyperlaneMidnightError::SubmitterMalformed {
-            message: "missing `delivered` boolean in response".to_string(),
-            raw: truncate(&raw, 1024),
-        })
-        .map_err(Into::into)
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Helper: take the relayer-supplied `(message, metadata, contract_address)`
@@ -497,6 +484,50 @@ mod tests {
         assert!(
             msg.contains("malformed") || msg.contains("eof") || msg.contains("expected"),
             "actual error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_elapses_and_kills_child() {
+        // Write a tiny shell stub that hangs forever. Use it as the
+        // submitter binary so `run_submitter` has to enforce its own
+        // timeout. Validates both H1 deliverables (timeout surfaces as
+        // `SubmitterTimeout`; `kill_on_drop` reaps the child promptly).
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "midnight-toolkit-timeout-{}.sh",
+            std::process::id()
+        ));
+        {
+            let mut f = std::fs::File::create(&tmp).unwrap();
+            f.write_all(b"#!/bin/sh\nsleep 5\n").unwrap();
+            std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let mut ctx = ctx();
+        ctx.binary_path = tmp.to_string_lossy().into_owned();
+        let payload = serde_json::json!({"op": "submit"});
+
+        let started = std::time::Instant::now();
+        let err = run_submitter(&ctx, &payload, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        let elapsed = started.elapsed();
+
+        let _ = std::fs::remove_file(&tmp);
+
+        // If `kill_on_drop` were off, the future would block until the
+        // child's `sleep 5` returned — well past 2 seconds.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "timeout future hung for {elapsed:?} — kill_on_drop likely missing"
+        );
+        let display = format!("{err}");
+        assert!(
+            display.contains("timeout") || display.contains("SIGKILL"),
+            "actual error: {display}"
         );
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -225,7 +225,11 @@ pub async fn query_delivered(
 ) -> ChainResult<bool> {
     let request = IsDeliveredRequest {
         op: "isDelivered",
-        contract_address: format!("0x{contract_address:x}"),
+        // Midnight contract addresses are bare hex — `@midnight-ntwrk/midnight-js-utils`
+        // throws TypeError on any leading `0x`. Hyperlane addresses elsewhere
+        // (EVM, Substrate, our own config parser) are `0x`-prefixed, so we
+        // strip only at the Midnight-SDK seam.
+        contract_address: format!("{contract_address:x}"),
         indexer_graphql_url: ctx.indexer_graphql_url.clone(),
         indexer_ws_url: ctx.indexer_ws_url.clone(),
         network_id: ctx.network_id.clone(),
@@ -333,7 +337,8 @@ pub fn build_request<'a>(
 ) -> SubmitRequest<'a> {
     SubmitRequest {
         op: "submit",
-        contract_address: format!("0x{contract_address:x}"),
+        // See `query_delivered` — Midnight rejects `0x` on contract addresses.
+        contract_address: format!("{contract_address:x}"),
         indexer_graphql_url: ctx.indexer_graphql_url.clone(),
         indexer_ws_url: ctx.indexer_ws_url.clone(),
         node_rpc_url: ctx.node_rpc_url.clone(),

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -1,12 +1,3 @@
-//! Subprocess wrapper for the Midnight handle submitter.
-//!
-//! The Midnight contract layer only has a TypeScript SDK
-//! (`@midnight-ntwrk/midnight-js-contracts`), so the Rust relayer drives it
-//! by spawning a Node.js submitter binary. The submitter reads a JSON
-//! payload from stdin, calls the `handle` circuit, and prints a JSON
-//! response on stdout. Anything else (logs, traces) goes to stderr and is
-//! captured into the error variants so operators see what failed.
-
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -18,153 +9,124 @@ use hyperlane_core::{ChainResult, HyperlaneMessage, H256, H512};
 
 use crate::HyperlaneMidnightError;
 
-/// Wall-clock cap on a single `submit` invocation. Generous so a busy ZK
-/// proof server has headroom; tight enough that a wedged child does not
-/// block the relayer worker future forever.
 const SUBMIT_TIMEOUT: Duration = Duration::from_secs(120);
-
-/// Wall-clock cap on a single `isDelivered` query. No proof work — just
-/// indexer fetch + ledger decode — so much tighter than `SUBMIT_TIMEOUT`.
 const DELIVERED_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// JSON payload written to the submitter's stdin.
-///
-/// Field names use camelCase to match the Node ecosystem convention. All
-/// byte arrays are encoded as `0x`-prefixed lowercase hex.
+/// JSON payload for the `submit` op.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitRequest<'a> {
-    /// Operation discriminator. Always `"submit"` for handle submissions.
+    /// Operation discriminator.
     pub op: &'static str,
-    /// Address of the deployed WarpRoute contract on Midnight.
+    /// Deployed WarpRoute contract address.
     pub contract_address: String,
-    /// Indexer GraphQL endpoint (HTTP) so the submitter can sync state.
+    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL WebSocket endpoint, derived from the HTTP URL.
+    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
     /// Midnight node RPC endpoint.
     pub node_rpc_url: String,
-    /// Proof server endpoint (HTTP).
+    /// Proof server endpoint.
     pub proof_server_url: String,
-    /// Midnight network ID (e.g. `undeployed`, `testnet`, `mainnet`).
+    /// Midnight network id.
     pub network_id: String,
-    /// Hyperlane message in canonical field form (numbers as decimal strings
-    /// in JSON; bytes as `0x`-prefixed hex).
+    /// Hyperlane message.
     pub message: WireMessage<'a>,
-    /// Metadata fields extracted from MessageIdMultisigIsmMetadata.
+    /// MessageIdMultisigIsm metadata.
     pub metadata: WireMetadata,
-    /// Whether the recipient bytes should be decoded as a contract address
-    /// (vs. user address). The WarpRoute exposes both variants via the
-    /// circuit's final parameter.
+    /// Whether the recipient is a contract address.
     pub is_contract_recipient: bool,
 }
 
-/// Wire-format HyperlaneMessage. Numbers go through as decimal strings so
-/// JavaScript's BigInt can ingest them without precision loss.
+/// Wire-format HyperlaneMessage.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WireMessage<'a> {
     /// Hyperlane protocol version.
     pub version: u8,
-    /// Origin-chain dispatch nonce (decimal string).
+    /// Origin-chain dispatch nonce (decimal string for JS BigInt safety).
     pub nonce: String,
     /// Origin domain id.
     pub origin: u32,
-    /// `0x`-prefixed hex, 32 bytes.
+    /// `0x`-prefixed 32-byte hex.
     pub sender: String,
-    /// Destination domain id (should match this chain's local domain).
+    /// Destination domain id.
     pub destination: u32,
-    /// `0x`-prefixed hex, 32 bytes.
+    /// `0x`-prefixed 32-byte hex.
     pub recipient: String,
-    /// `0x`-prefixed hex, 64 bytes (TokenMessage payload).
+    /// `0x`-prefixed 64-byte hex (TokenMessage payload).
     pub body: String,
-    /// Reference into the borrowed source message so we don't need to clone
-    /// the body bytes when serializing. The hex string above is what the
-    /// submitter actually consumes; this field is `#[serde(skip)]`.
+    /// Avoids cloning the body bytes during serialization.
     #[serde(skip)]
     pub _marker: std::marker::PhantomData<&'a HyperlaneMessage>,
 }
 
-/// Wire-format MessageIdMultisigIsm metadata, broken out per field so the
-/// submitter doesn't have to know the upstream packed layout.
+/// Wire-format ISM metadata.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WireMetadata {
-    /// Origin-chain merkle tree hook address, `0x`-prefixed 32-byte hex.
+    /// Origin-chain merkle tree hook address.
     pub merkle_tree_hook: String,
-    /// Validator-signed merkle root, `0x`-prefixed 32-byte hex.
+    /// Validator-signed merkle root.
     pub root: String,
-    /// Index of this message in the origin chain's merkle tree.
+    /// Merkle tree index.
     pub index: u32,
-    /// Validator signatures, padded to 16 entries. Each entry is
-    /// `0x`-prefixed 65-byte hex (`r || s || v`).
+    /// Validator signatures, padded to 16 entries.
     pub signatures: Vec<String>,
 }
 
-/// JSON envelope written by the submitter on stdout.
+/// JSON envelope returned by the `submit` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitResponse {
-    /// `0x`-prefixed transaction hash. Present on success, absent on error.
+    /// Transaction hash on success.
     #[serde(default)]
     pub tx_hash: Option<String>,
-    /// Block height the transaction was included in. Reserved for future
-    /// use by the operations dashboards (#34 scraper); parsed today so the
-    /// JSON shape is stable.
+    /// Block height on success.
     #[serde(default)]
     #[allow(dead_code)]
     pub block_height: Option<u64>,
-    /// Structured error block. Present iff submission failed.
+    /// Structured error on failure.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// Structured error reported by the submitter.
+/// Structured error from the submitter.
 #[derive(Debug, Deserialize)]
 pub struct SubmitError {
-    /// Short tag. Known values: `proofTimeout`, `insufficientDust`,
-    /// `staleState`, `replay`, `signerUnavailable`, `rpcUnreachable`,
-    /// `contractRevert`, `internal`.
+    /// Short kind tag.
     pub kind: String,
     /// Human-readable message.
     pub message: String,
 }
 
-/// Result of a successful submission, ready to be wrapped in `TxOutcome`.
+/// Successful submission outcome.
 #[derive(Debug)]
 pub struct ToolkitOutcome {
-    /// Transaction hash widened to 64 bytes (H256 → H512 for `TxOutcome`).
+    /// Transaction hash (Midnight 32 bytes packed into the low end of H512).
     pub transaction_id: H512,
-    /// Whether the contract reported success. The submitter only reports
-    /// `true` when the on-chain replay set was updated for this message.
+    /// Whether the contract reported success.
     pub executed: bool,
 }
 
-/// Configuration values the toolkit wrapper needs at spawn time. These are
-/// not all in `ConnectionConf` because some (proof server, network id) are
-/// agent-side env, not chain config — operators set them via env vars.
+/// Runtime values needed at spawn time.
 #[derive(Debug, Clone)]
 pub struct ToolkitContext {
-    /// Path to the submitter binary (or wrapper script). Comes from
-    /// `ConnectionConf::toolkit_path`.
+    /// Path to the submitter binary.
     pub binary_path: String,
-    /// Indexer GraphQL HTTP endpoint.
+    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL WebSocket endpoint.
+    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
     /// Midnight node RPC endpoint.
     pub node_rpc_url: String,
-    /// Proof server URL.
+    /// Proof server endpoint.
     pub proof_server_url: String,
     /// Midnight network id.
     pub network_id: String,
 }
 
-/// Invoke the submitter for one message and return the resulting outcome.
-///
-/// On failure each known submitter error kind maps to an explicit
-/// [`HyperlaneMidnightError`] variant so the agent can surface meaningful
-/// retry / alert behavior.
+/// Invoke the submitter for one message and return its outcome.
 pub async fn submit_handle(
     ctx: &ToolkitContext,
     request: &SubmitRequest<'_>,
@@ -204,10 +166,6 @@ fn parse_tx_hash(hex_input: &str, raw: &str) -> Result<H512, HyperlaneMidnightEr
         raw: truncate(raw, 1024),
     })?;
 
-    // Midnight tx hashes are 32 bytes; the relayer's `TxOutcome` carries an
-    // H512 to accommodate longer hashes from other chains (e.g. Solana
-    // signatures). Pack the 32 bytes into the high half and leave the rest
-    // zeroed so the H512 round-trip is deterministic.
     if bytes.len() > 64 {
         return Err(HyperlaneMidnightError::SubmitterMalformed {
             message: format!("txHash too long: {} bytes", bytes.len()),
@@ -229,42 +187,37 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-/// JSON payload for the `delivered(id)` query. Same submitter binary, dispatched
-/// on the `op` field.
+/// JSON payload for the `isDelivered` op.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IsDeliveredRequest {
     /// Operation discriminator.
     pub op: &'static str,
-    /// Address of the deployed WarpRoute contract on Midnight.
+    /// Deployed WarpRoute contract address.
     pub contract_address: String,
     /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL WebSocket endpoint.
+    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight network ID.
+    /// Midnight network id.
     pub network_id: String,
-    /// Message id to check, `0x`-prefixed 32-byte hex.
+    /// Message id to check.
     pub message_id: String,
 }
 
-/// JSON envelope for `delivered(id)`.
+/// JSON envelope returned by the `isDelivered` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IsDeliveredResponse {
-    /// True iff the WarpRoute contract has marked this `messageId` delivered.
-    /// Absent when the submitter reports a structured error.
+    /// Membership flag on success.
     #[serde(default)]
     pub delivered: Option<bool>,
-    /// Structured error block. Present iff the query failed.
+    /// Structured error on failure.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// Query the on-chain `deliveries: Set<Bytes<32>>` membership for `message_id`
-/// via the submitter subprocess. The submitter handles state deserialization
-/// (Midnight ledger encoding) on the TS side; the Rust crate stays
-/// runtime-free.
+/// Query on-chain `deliveries` membership via the submitter.
 pub async fn query_delivered(
     ctx: &ToolkitContext,
     contract_address: H256,
@@ -303,15 +256,6 @@ pub async fn query_delivered(
         .map_err(Into::into)
 }
 
-/// Spawn the submitter binary, write `request` as JSON to stdin, wait up
-/// to `timeout` for the child to exit, and return its stdout as a string.
-///
-/// The child is spawned with `kill_on_drop(true)` so that if the calling
-/// future is cancelled (relayer shutdown, timeout, parent task drop) the
-/// Node process is reaped instead of leaked. On a timeout elapse the
-/// `Child` handle goes out of scope mid-await and SIGKILL is delivered;
-/// the error surfaces as `SubmitterTimeout` so callers can map it onto a
-/// dedicated retry classification.
 async fn run_submitter<R: Serialize>(
     ctx: &ToolkitContext,
     request: &R,
@@ -361,8 +305,6 @@ async fn run_submitter<R: Serialize>(
             .into());
         }
         Err(_elapsed) => {
-            // `child` dropped here → kill_on_drop(true) SIGKILLs the Node
-            // process before we return.
             return Err(HyperlaneMidnightError::SubmitterTimeout {
                 elapsed_secs: timeout.as_secs(),
             }
@@ -381,8 +323,7 @@ async fn run_submitter<R: Serialize>(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// Helper: take the relayer-supplied `(message, metadata, contract_address)`
-/// triple and produce the JSON wire form expected by the submitter.
+/// Build a `SubmitRequest` from a HyperlaneMessage + metadata.
 pub fn build_request<'a>(
     contract_address: H256,
     ctx: &ToolkitContext,
@@ -465,34 +406,22 @@ mod tests {
         let request = build_request(H256::zero(), &ctx, &message, metadata(), false);
         let err = submit_handle(&ctx, &request).await.unwrap_err();
         let display = format!("{err}");
-        assert!(
-            display.contains("not configured") || display.contains("toolkitPath"),
-            "actual error: {display}"
-        );
+        assert!(display.contains("not configured") || display.contains("toolkitPath"));
     }
 
     #[tokio::test]
     async fn empty_stdout_maps_to_malformed_error() {
-        // `/usr/bin/true` exits 0 with no stdout. The wrapper must surface
-        // this as `SubmitterMalformed` (JSON parse failure on empty input).
         let mut ctx = ctx();
         ctx.binary_path = "/usr/bin/true".to_string();
         let message = HyperlaneMessage::default();
         let request = build_request(H256::zero(), &ctx, &message, metadata(), false);
         let err = submit_handle(&ctx, &request).await.unwrap_err();
         let msg = format!("{err:?}").to_lowercase();
-        assert!(
-            msg.contains("malformed") || msg.contains("eof") || msg.contains("expected"),
-            "actual error: {msg}"
-        );
+        assert!(msg.contains("malformed") || msg.contains("eof") || msg.contains("expected"));
     }
 
     #[tokio::test]
     async fn timeout_elapses_and_kills_child() {
-        // Write a tiny shell stub that hangs forever. Use it as the
-        // submitter binary so `run_submitter` has to enforce its own
-        // timeout. Validates both H1 deliverables (timeout surfaces as
-        // `SubmitterTimeout`; `kill_on_drop` reaps the child promptly).
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
 
@@ -518,16 +447,8 @@ mod tests {
 
         let _ = std::fs::remove_file(&tmp);
 
-        // If `kill_on_drop` were off, the future would block until the
-        // child's `sleep 5` returned — well past 2 seconds.
-        assert!(
-            elapsed < Duration::from_secs(2),
-            "timeout future hung for {elapsed:?} — kill_on_drop likely missing"
-        );
+        assert!(elapsed < Duration::from_secs(2));
         let display = format!("{err}");
-        assert!(
-            display.contains("timeout") || display.contains("SIGKILL"),
-            "actual error: {display}"
-        );
+        assert!(display.contains("timeout") || display.contains("SIGKILL"));
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -1,0 +1,502 @@
+//! Subprocess wrapper for the Midnight handle submitter.
+//!
+//! The Midnight contract layer only has a TypeScript SDK
+//! (`@midnight-ntwrk/midnight-js-contracts`), so the Rust relayer drives it
+//! by spawning a Node.js submitter binary. The submitter reads a JSON
+//! payload from stdin, calls the `handle` circuit, and prints a JSON
+//! response on stdout. Anything else (logs, traces) goes to stderr and is
+//! captured into the error variants so operators see what failed.
+
+use std::process::Stdio;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use hyperlane_core::{ChainResult, HyperlaneMessage, H256, H512};
+
+use crate::HyperlaneMidnightError;
+
+/// JSON payload written to the submitter's stdin.
+///
+/// Field names use camelCase to match the Node ecosystem convention. All
+/// byte arrays are encoded as `0x`-prefixed lowercase hex.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitRequest<'a> {
+    /// Operation discriminator. Always `"submit"` for handle submissions.
+    pub op: &'static str,
+    /// Address of the deployed WarpRoute contract on Midnight.
+    pub contract_address: String,
+    /// Indexer GraphQL endpoint (HTTP) so the submitter can sync state.
+    pub indexer_graphql_url: String,
+    /// Indexer GraphQL WebSocket endpoint, derived from the HTTP URL.
+    pub indexer_ws_url: String,
+    /// Midnight node RPC endpoint.
+    pub node_rpc_url: String,
+    /// Proof server endpoint (HTTP).
+    pub proof_server_url: String,
+    /// Midnight network ID (e.g. `undeployed`, `testnet`, `mainnet`).
+    pub network_id: String,
+    /// Hyperlane message in canonical field form (numbers as decimal strings
+    /// in JSON; bytes as `0x`-prefixed hex).
+    pub message: WireMessage<'a>,
+    /// Metadata fields extracted from MessageIdMultisigIsmMetadata.
+    pub metadata: WireMetadata,
+    /// Whether the recipient bytes should be decoded as a contract address
+    /// (vs. user address). The WarpRoute exposes both variants via the
+    /// circuit's final parameter.
+    pub is_contract_recipient: bool,
+}
+
+/// Wire-format HyperlaneMessage. Numbers go through as decimal strings so
+/// JavaScript's BigInt can ingest them without precision loss.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireMessage<'a> {
+    /// Hyperlane protocol version.
+    pub version: u8,
+    /// Origin-chain dispatch nonce (decimal string).
+    pub nonce: String,
+    /// Origin domain id.
+    pub origin: u32,
+    /// `0x`-prefixed hex, 32 bytes.
+    pub sender: String,
+    /// Destination domain id (should match this chain's local domain).
+    pub destination: u32,
+    /// `0x`-prefixed hex, 32 bytes.
+    pub recipient: String,
+    /// `0x`-prefixed hex, 64 bytes (TokenMessage payload).
+    pub body: String,
+    /// Reference into the borrowed source message so we don't need to clone
+    /// the body bytes when serializing. The hex string above is what the
+    /// submitter actually consumes; this field is `#[serde(skip)]`.
+    #[serde(skip)]
+    pub _marker: std::marker::PhantomData<&'a HyperlaneMessage>,
+}
+
+/// Wire-format MessageIdMultisigIsm metadata, broken out per field so the
+/// submitter doesn't have to know the upstream packed layout.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireMetadata {
+    /// Origin-chain merkle tree hook address, `0x`-prefixed 32-byte hex.
+    pub merkle_tree_hook: String,
+    /// Validator-signed merkle root, `0x`-prefixed 32-byte hex.
+    pub root: String,
+    /// Index of this message in the origin chain's merkle tree.
+    pub index: u32,
+    /// Validator signatures, padded to 16 entries. Each entry is
+    /// `0x`-prefixed 65-byte hex (`r || s || v`).
+    pub signatures: Vec<String>,
+}
+
+/// JSON envelope written by the submitter on stdout.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitResponse {
+    /// `0x`-prefixed transaction hash. Present on success, absent on error.
+    #[serde(default)]
+    pub tx_hash: Option<String>,
+    /// Block height the transaction was included in. Reserved for future
+    /// use by the operations dashboards (#34 scraper); parsed today so the
+    /// JSON shape is stable.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub block_height: Option<u64>,
+    /// Structured error block. Present iff submission failed.
+    #[serde(default)]
+    pub error: Option<SubmitError>,
+}
+
+/// Structured error reported by the submitter.
+#[derive(Debug, Deserialize)]
+pub struct SubmitError {
+    /// Short tag. Known values: `proofTimeout`, `insufficientDust`,
+    /// `staleState`, `replay`, `signerUnavailable`, `rpcUnreachable`,
+    /// `contractRevert`, `internal`.
+    pub kind: String,
+    /// Human-readable message.
+    pub message: String,
+}
+
+/// Result of a successful submission, ready to be wrapped in `TxOutcome`.
+#[derive(Debug)]
+pub struct ToolkitOutcome {
+    /// Transaction hash widened to 64 bytes (H256 → H512 for `TxOutcome`).
+    pub transaction_id: H512,
+    /// Whether the contract reported success. The submitter only reports
+    /// `true` when the on-chain replay set was updated for this message.
+    pub executed: bool,
+}
+
+/// Configuration values the toolkit wrapper needs at spawn time. These are
+/// not all in `ConnectionConf` because some (proof server, network id) are
+/// agent-side env, not chain config — operators set them via env vars.
+#[derive(Debug, Clone)]
+pub struct ToolkitContext {
+    /// Path to the submitter binary (or wrapper script). Comes from
+    /// `ConnectionConf::toolkit_path`.
+    pub binary_path: String,
+    /// Indexer GraphQL HTTP endpoint.
+    pub indexer_graphql_url: String,
+    /// Indexer GraphQL WebSocket endpoint.
+    pub indexer_ws_url: String,
+    /// Midnight node RPC endpoint.
+    pub node_rpc_url: String,
+    /// Proof server URL.
+    pub proof_server_url: String,
+    /// Midnight network id.
+    pub network_id: String,
+}
+
+/// Invoke the submitter for one message and return the resulting outcome.
+///
+/// On failure each known submitter error kind maps to an explicit
+/// [`HyperlaneMidnightError`] variant so the agent can surface meaningful
+/// retry / alert behavior.
+pub async fn submit_handle(
+    ctx: &ToolkitContext,
+    request: &SubmitRequest<'_>,
+) -> ChainResult<ToolkitOutcome> {
+    if ctx.binary_path.is_empty() {
+        return Err(HyperlaneMidnightError::MissingSubmitterPath.into());
+    }
+
+    let payload = serde_json::to_vec(request).map_err(HyperlaneMidnightError::from)?;
+
+    let mut child = Command::new(&ctx.binary_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+            path: ctx.binary_path.clone(),
+            source,
+        })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(&payload)
+            .await
+            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+                path: ctx.binary_path.clone(),
+                source,
+            })?;
+        stdin
+            .shutdown()
+            .await
+            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+                path: ctx.binary_path.clone(),
+                source,
+            })?;
+    }
+
+    let output =
+        child
+            .wait_with_output()
+            .await
+            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+                path: ctx.binary_path.clone(),
+                source,
+            })?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        return Err(HyperlaneMidnightError::SubmitterFailed {
+            status: output.status.code().unwrap_or(-1),
+            stderr,
+        }
+        .into());
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).to_string();
+    let response: SubmitResponse =
+        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+            message: err.to_string(),
+            raw: truncate(&raw, 1024),
+        })?;
+
+    if let Some(error) = response.error {
+        return Err(HyperlaneMidnightError::SubmitterReported {
+            kind: error.kind,
+            message: error.message,
+        }
+        .into());
+    }
+
+    let tx_hash = response.tx_hash.ok_or_else(|| {
+        HyperlaneMidnightError::SubmitterMalformed {
+            message: "missing `txHash` in response".to_string(),
+            raw: truncate(&raw, 1024),
+        }
+    })?;
+
+    Ok(ToolkitOutcome {
+        transaction_id: parse_tx_hash(&tx_hash, &raw)?,
+        executed: true,
+    })
+}
+
+fn parse_tx_hash(hex_input: &str, raw: &str) -> Result<H512, HyperlaneMidnightError> {
+    let trimmed = hex_input.strip_prefix("0x").unwrap_or(hex_input);
+    let bytes = hex::decode(trimmed).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+        message: format!("invalid txHash hex: {err}"),
+        raw: truncate(raw, 1024),
+    })?;
+
+    // Midnight tx hashes are 32 bytes; the relayer's `TxOutcome` carries an
+    // H512 to accommodate longer hashes from other chains (e.g. Solana
+    // signatures). Pack the 32 bytes into the high half and leave the rest
+    // zeroed so the H512 round-trip is deterministic.
+    if bytes.len() > 64 {
+        return Err(HyperlaneMidnightError::SubmitterMalformed {
+            message: format!("txHash too long: {} bytes", bytes.len()),
+            raw: truncate(raw, 1024),
+        });
+    }
+    let mut buf = [0u8; 64];
+    buf[..bytes.len()].copy_from_slice(&bytes);
+    Ok(H512::from(buf))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut out = s[..max].to_string();
+        out.push_str("…[truncated]");
+        out
+    }
+}
+
+/// JSON payload for the `delivered(id)` query. Same submitter binary, dispatched
+/// on the `op` field.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IsDeliveredRequest {
+    /// Operation discriminator.
+    pub op: &'static str,
+    /// Address of the deployed WarpRoute contract on Midnight.
+    pub contract_address: String,
+    /// Indexer GraphQL endpoint (HTTP).
+    pub indexer_graphql_url: String,
+    /// Indexer GraphQL WebSocket endpoint.
+    pub indexer_ws_url: String,
+    /// Midnight network ID.
+    pub network_id: String,
+    /// Message id to check, `0x`-prefixed 32-byte hex.
+    pub message_id: String,
+}
+
+/// JSON envelope for `delivered(id)`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IsDeliveredResponse {
+    /// True iff the WarpRoute contract has marked this `messageId` delivered.
+    /// Absent when the submitter reports a structured error.
+    #[serde(default)]
+    pub delivered: Option<bool>,
+    /// Structured error block. Present iff the query failed.
+    #[serde(default)]
+    pub error: Option<SubmitError>,
+}
+
+/// Query the on-chain `deliveries: Set<Bytes<32>>` membership for `message_id`
+/// via the submitter subprocess. The submitter handles state deserialization
+/// (Midnight ledger encoding) on the TS side; the Rust crate stays
+/// runtime-free.
+pub async fn query_delivered(
+    ctx: &ToolkitContext,
+    contract_address: H256,
+    message_id: H256,
+) -> ChainResult<bool> {
+    if ctx.binary_path.is_empty() {
+        return Err(HyperlaneMidnightError::MissingSubmitterPath.into());
+    }
+
+    let request = IsDeliveredRequest {
+        op: "isDelivered",
+        contract_address: format!("0x{contract_address:x}"),
+        indexer_graphql_url: ctx.indexer_graphql_url.clone(),
+        indexer_ws_url: ctx.indexer_ws_url.clone(),
+        network_id: ctx.network_id.clone(),
+        message_id: format!("0x{message_id:x}"),
+    };
+    let payload = serde_json::to_vec(&request).map_err(HyperlaneMidnightError::from)?;
+
+    let mut child = Command::new(&ctx.binary_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+            path: ctx.binary_path.clone(),
+            source,
+        })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(&payload)
+            .await
+            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+                path: ctx.binary_path.clone(),
+                source,
+            })?;
+        stdin
+            .shutdown()
+            .await
+            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+                path: ctx.binary_path.clone(),
+                source,
+            })?;
+    }
+
+    let output =
+        child
+            .wait_with_output()
+            .await
+            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+                path: ctx.binary_path.clone(),
+                source,
+            })?;
+
+    if !output.status.success() {
+        return Err(HyperlaneMidnightError::SubmitterFailed {
+            status: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        }
+        .into());
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).to_string();
+    let response: IsDeliveredResponse =
+        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+            message: err.to_string(),
+            raw: truncate(&raw, 1024),
+        })?;
+
+    if let Some(error) = response.error {
+        return Err(HyperlaneMidnightError::SubmitterReported {
+            kind: error.kind,
+            message: error.message,
+        }
+        .into());
+    }
+
+    response
+        .delivered
+        .ok_or_else(|| HyperlaneMidnightError::SubmitterMalformed {
+            message: "missing `delivered` boolean in response".to_string(),
+            raw: truncate(&raw, 1024),
+        })
+        .map_err(Into::into)
+}
+
+/// Helper: take the relayer-supplied `(message, metadata, contract_address)`
+/// triple and produce the JSON wire form expected by the submitter.
+pub fn build_request<'a>(
+    contract_address: H256,
+    ctx: &ToolkitContext,
+    message: &'a HyperlaneMessage,
+    metadata: WireMetadata,
+    is_contract_recipient: bool,
+) -> SubmitRequest<'a> {
+    SubmitRequest {
+        op: "submit",
+        contract_address: format!("0x{contract_address:x}"),
+        indexer_graphql_url: ctx.indexer_graphql_url.clone(),
+        indexer_ws_url: ctx.indexer_ws_url.clone(),
+        node_rpc_url: ctx.node_rpc_url.clone(),
+        proof_server_url: ctx.proof_server_url.clone(),
+        network_id: ctx.network_id.clone(),
+        message: WireMessage {
+            version: message.version,
+            nonce: message.nonce.to_string(),
+            origin: message.origin,
+            sender: format!("0x{:x}", message.sender),
+            destination: message.destination,
+            recipient: format!("0x{:x}", message.recipient),
+            body: format!("0x{}", hex::encode(&message.body)),
+            _marker: std::marker::PhantomData,
+        },
+        metadata,
+        is_contract_recipient,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolkitContext {
+        ToolkitContext {
+            binary_path: "/bin/false".to_string(),
+            indexer_graphql_url: "http://indexer/graphql".to_string(),
+            indexer_ws_url: "ws://indexer/graphql".to_string(),
+            node_rpc_url: "http://node:9944".to_string(),
+            proof_server_url: "http://proof:6300".to_string(),
+            network_id: "undeployed".to_string(),
+        }
+    }
+
+    fn metadata() -> WireMetadata {
+        WireMetadata {
+            merkle_tree_hook: "0x00".to_string(),
+            root: "0x11".to_string(),
+            index: 7,
+            signatures: vec!["0x22".to_string(); 16],
+        }
+    }
+
+    #[test]
+    fn build_request_serializes_to_expected_shape() {
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce: 42,
+            origin: 5,
+            sender: H256::from_low_u64_be(0xAB),
+            destination: 1234,
+            recipient: H256::from_low_u64_be(0xCD),
+            body: vec![0u8; 64],
+        };
+        let request = build_request(H256::from_low_u64_be(1), &ctx(), &message, metadata(), false);
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"op\":\"submit\""));
+        assert!(json.contains("\"version\":3"));
+        assert!(json.contains("\"nonce\":\"42\""));
+        assert!(json.contains("\"isContractRecipient\":false"));
+        assert!(json.contains("\"signatures\":[\"0x22\","));
+    }
+
+    #[tokio::test]
+    async fn missing_submitter_path_short_circuits() {
+        let mut ctx = ctx();
+        ctx.binary_path.clear();
+        let message = HyperlaneMessage::default();
+        let request = build_request(H256::zero(), &ctx, &message, metadata(), false);
+        let err = submit_handle(&ctx, &request).await.unwrap_err();
+        let display = format!("{err}");
+        assert!(
+            display.contains("not configured") || display.contains("toolkitPath"),
+            "actual error: {display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_stdout_maps_to_malformed_error() {
+        // `/usr/bin/true` exits 0 with no stdout. The wrapper must surface
+        // this as `SubmitterMalformed` (JSON parse failure on empty input).
+        let mut ctx = ctx();
+        ctx.binary_path = "/usr/bin/true".to_string();
+        let message = HyperlaneMessage::default();
+        let request = build_request(H256::zero(), &ctx, &message, metadata(), false);
+        let err = submit_handle(&ctx, &request).await.unwrap_err();
+        let msg = format!("{err:?}").to_lowercase();
+        assert!(
+            msg.contains("malformed") || msg.contains("eof") || msg.contains("expected"),
+            "actual error: {msg}"
+        );
+    }
+}

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -302,9 +302,10 @@ impl ChainConf {
                 h_aleo::application::AleoApplicationOperationVerifier::new(),
             )
                 as Box<dyn ApplicationOperationVerifier>),
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: application operation verifier is not yet implemented (see issues #14-#20)"
-            )),
+            ChainConnectionConf::Midnight(_) => Ok(Box::new(
+                h_midnight::application::MidnightApplicationOperationVerifier::new(),
+            )
+                as Box<dyn ApplicationOperationVerifier>),
         };
 
         result.context(ctx)
@@ -610,9 +611,12 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<HyperlaneMessage>>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: message dispatch indexer is not yet implemented (see issue #16)"
-            )),
+            ChainConnectionConf::Midnight(_) => {
+                // TODO(#16): real dispatch indexer reading from the WarpRoute
+                // contract state via the Midnight indexer client (#14).
+                Ok(Box::new(h_midnight::stubs::MidnightMessageIndexerStub::new())
+                    as Box<dyn SequenceAwareIndexer<HyperlaneMessage>>)
+            }
         }
         .context(ctx)
     }
@@ -861,9 +865,12 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<InterchainGasPayment>>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: interchain gas payment indexer is not yet implemented (see issue #19)"
-            )),
+            ChainConnectionConf::Midnight(_) => {
+                // TODO(#19): real IGP indexer reading payments from the IGP
+                // contract state via the Midnight indexer client (#14).
+                Ok(Box::new(h_midnight::stubs::MidnightIgpIndexerStub::new())
+                    as Box<dyn SequenceAwareIndexer<InterchainGasPayment>>)
+            }
         }
         .context(ctx)
     }
@@ -952,9 +959,13 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: merkle tree hook indexer is not yet implemented (see issue #15)"
-            )),
+            ChainConnectionConf::Midnight(_) => {
+                // TODO(#15): real merkle-tree-hook indexer reading leaf
+                // insertions from the WarpRoute contract state via the
+                // Midnight indexer client (#14).
+                Ok(Box::new(h_midnight::stubs::MidnightMerkleTreeIndexerStub::new())
+                    as Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>)
+            }
         }
         .context(ctx)
     }
@@ -1043,9 +1054,23 @@ impl ChainConf {
                     h_aleo::AleoValidatorAnnounce::new(provider, &locator, conf);
                 Ok(Box::new(validator_announce) as Box<dyn ValidatorAnnounce>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: ValidatorAnnounce is not yet implemented (see issue #33)"
-            )),
+            ChainConnectionConf::Midnight(conf) => {
+                // TODO(#33): real ValidatorAnnounce backed by the on-chain
+                // ValidatorAnnounce contract via the Midnight indexer
+                // client (#14).
+                let indexer = h_midnight::MidnightIndexerClient::new(
+                    conf.indexer_graphql_url.clone(),
+                );
+                let provider = h_midnight::MidnightProvider::new(
+                    locator.domain.clone(),
+                    indexer,
+                );
+                Ok(Box::new(h_midnight::stubs::MidnightValidatorAnnounceStub::new(
+                    locator.address,
+                    locator.domain.clone(),
+                    provider,
+                )) as Box<dyn ValidatorAnnounce>)
+            }
         }
         .context("Building ValidatorAnnounce")
     }
@@ -1120,9 +1145,25 @@ impl ChainConf {
                 let ism = h_aleo::AleoIsm::new(provider, &locator, conf)?;
                 Ok(Box::new(ism) as Box<dyn InterchainSecurityModule>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: InterchainSecurityModule is not yet implemented (see issue #14)"
-            )),
+            ChainConnectionConf::Midnight(conf) => {
+                // TODO(#14): read module type from chain state once the
+                // state reader lands — Midnight only has MessageIdMultisig
+                // today, but the contract design allows other ISM variants
+                // to be wired in later.
+                let indexer = h_midnight::MidnightIndexerClient::new(
+                    conf.indexer_graphql_url.clone(),
+                );
+                let provider = h_midnight::MidnightProvider::new(
+                    locator.domain.clone(),
+                    indexer,
+                );
+                let ism = h_midnight::ism::MidnightInterchainSecurityModule::new(
+                    locator.address,
+                    locator.domain.clone(),
+                    provider,
+                );
+                Ok(Box::new(ism) as Box<dyn InterchainSecurityModule>)
+            }
         }
         .context(ctx)
     }
@@ -1188,9 +1229,26 @@ impl ChainConf {
                 let ism = h_aleo::AleoIsm::new(provider, &locator, conf)?;
                 Ok(Box::new(ism) as Box<dyn MultisigIsm>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: MultisigIsm is not yet implemented (see issue #14)"
-            )),
+            ChainConnectionConf::Midnight(conf) => {
+                // TODO(#14): read validators + threshold from chain state.
+                // The pair must migrate together — set/threshold drift would
+                // either soft-brick delivery (wrong validators) or
+                // invalidate on-chain ISM verification.
+                let indexer = h_midnight::MidnightIndexerClient::new(
+                    conf.indexer_graphql_url.clone(),
+                );
+                let provider = h_midnight::MidnightProvider::new(
+                    locator.domain.clone(),
+                    indexer,
+                );
+                let ism = h_midnight::ism::MidnightMultisigIsm::new(
+                    locator.address,
+                    locator.domain.clone(),
+                    provider,
+                    conf,
+                );
+                Ok(Box::new(ism) as Box<dyn MultisigIsm>)
+            }
         }
         .context(ctx)
     }

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -445,9 +445,11 @@ impl ChainConf {
                 let mailbox = h_aleo::AleoMailbox::new(provider, &locator, conf);
                 Ok(Box::new(mailbox) as Box<dyn Mailbox>)
             }
-            ChainConnectionConf::Midnight(_) => Err(eyre!(
-                "Midnight: Mailbox is not yet implemented (see issue #20)"
-            )),
+            ChainConnectionConf::Midnight(conf) => {
+                let mailbox =
+                    h_midnight::MidnightMailbox::new(&locator, conf).context(ctx)?;
+                Ok(Box::new(mailbox) as Box<dyn Mailbox>)
+            }
         }
         .context(ctx)
     }

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -11,7 +11,7 @@ use url::Url;
 use h_eth::TransactionOverrides;
 
 use hyperlane_core::config::{ConfigErrResultExt, OpSubmissionConfig};
-use hyperlane_core::{config::ConfigParsingError, HyperlaneDomainProtocol, NativeToken};
+use hyperlane_core::{config::ConfigParsingError, HyperlaneDomainProtocol, NativeToken, H160};
 
 use hyperlane_starknet as h_starknet;
 
@@ -798,12 +798,30 @@ pub fn build_midnight_connection_conf(
         .end()
         .map(|s| s.to_string());
 
+    // Validator addresses registered on the destination Midnight contract,
+    // in the order the on-chain `validators` vector was set at construction.
+    // The Midnight Mailbox uses this to sort signatures by validator-set
+    // index before handing the metadata to the submitter, so the on-chain
+    // two-pointer multisig walk accepts them.
+    let validators: Vec<H160> = chain
+        .chain(&mut local_err)
+        .get_opt_key("validators")
+        .into_array_iter()
+        .map(|values| {
+            values
+                .map(|v| v.parse_from_str::<H160>("Invalid Midnight validator address"))
+                .collect::<Result<Vec<H160>, _>>()
+                .unwrap_or_default()
+        })
+        .unwrap_or_default();
+
     if !local_err.is_ok() {
         err.merge(local_err);
         None
     } else {
         Some(ChainConnectionConf::Midnight(
-            hyperlane_midnight::ConnectionConf::new(indexer_graphql_url?, toolkit_path),
+            hyperlane_midnight::ConnectionConf::new(indexer_graphql_url?, toolkit_path)
+                .with_validators(validators),
         ))
     }
 }

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -815,13 +815,34 @@ pub fn build_midnight_connection_conf(
         })
         .unwrap_or_default();
 
+    // Optional multisig threshold; defaults to 0 if unset, which is fine
+    // because the relayer's MultisigIsm only matters when midnight is a
+    // destination and the agent operator should supply the same threshold
+    // that's configured on-chain. TODO(#14): read from chain state.
+    let threshold: u8 = match chain
+        .chain(&mut local_err)
+        .get_opt_key("threshold")
+        .parse_u64()
+        .end()
+    {
+        Some(v) => u8::try_from(v).unwrap_or_else(|_| {
+            local_err.push(
+                (&chain.cwp).add("threshold"),
+                eyre!("Midnight threshold {} exceeds u8 max (255)", v),
+            );
+            0
+        }),
+        None => 0,
+    };
+
     if !local_err.is_ok() {
         err.merge(local_err);
         None
     } else {
         Some(ChainConnectionConf::Midnight(
             hyperlane_midnight::ConnectionConf::new(indexer_graphql_url?, toolkit_path)
-                .with_validators(validators),
+                .with_validators(validators)
+                .with_threshold(threshold),
         ))
     }
 }

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -326,7 +326,9 @@ impl BuildableWithSignerConf for hyperlane_midnight::MidnightSigner {
             SignerConf::Node => Ok(hyperlane_midnight::MidnightSigner::new()),
             _ => bail!(format!(
                 "{conf:?} is not supported by midnight; use signer type `node` \
-                 (transaction signing is delegated to `midnight-node-toolkit` in issue #20)"
+                 (transaction signing is delegated to the handle-submitter \
+                  subprocess; relayer wallet seed comes from \
+                  `MIDNIGHT_RELAYER_SEED`)"
             )),
         }
     }


### PR DESCRIPTION
## What

Implements Hyperlane's `Mailbox` trait for Midnight in the agent fork. Closes the destination-side delivery half of the inbound flow.

- `MidnightMailbox` parses `MessageIdMultisigIsmMetadata`, spawns the handle submitter binary, returns `TxOutcome`.
- `delivered(id)` reuses the same submitter with `op: "isDelivered"`.
- Monolithic-WarpRoute defaults for `count` / `default_ism` / `recipient_ism` (0, self, self).
- Fixed-placeholder `process_estimate_costs` (matches Aleo — Midnight uses DUST-based fees the wallet computes at submission time).
- `process_calldata` / `delivered_calldata` are Lander-only → `NotImplemented` / `None`.
- Replaces the eyre stub at `hyperlane-base/src/settings/chains.rs:448` with the real builder.

## Divergence from ticket

The ticket says wrap `midnight-node-toolkit` directly. This PR uses a **custom Node submitter** in the `hyperlane-midnight` repo's new `relayer/` workspace instead — one subprocess hop instead of two, type-safe against the generated bindings, reuses devnet TS infrastructure. Full rationale on [issue #20](https://github.com/equilibriumco/hyperlane-midnight/issues/20#issuecomment-4487648988). `ConnectionConf.toolkit_path` is preserved as the field name.

Companion PR in `hyperlane-midnight` (the submitter itself): https://github.com/equilibriumco/hyperlane-midnight/pulls?q=is%3Apr+head%3Afeat%2F20-mailbox-submitter

## AC mapping

| AC | Where |
|---|---|
| `Mailbox` trait impl for Midnight | `chains/hyperlane-midnight/src/mailbox.rs` |
| Successful submission delivers a message | `process()` → `toolkit::submit_handle` → submitter → contract |
| Error paths mapped to `ChainCommunicationError` | `HyperlaneMidnightError` variants in `error.rs`; submitter error kinds → `SubmitterReported` |
| Retries and idempotency tested against local devnet | Documented in `relayer/src/devnet-smoke.ts` + relies on the contract's `Mailbox.deliveries` Set for the idempotency safety net |

## Open follow-ups

- Indexer client is intentionally one-method (`latest_block_height`) — full client lands in #14.
- `MidnightProvider` returns `NotImplemented` for block / txn lookups — same #14 follow-up.
- Real validator-quorum integration tested in #25 (inbound E2E).

## Notes

- `midnight-v1` is ~30 commits behind upstream `main` — flagged only, not merged here.
- Built clean: `cargo clippy --features aleo,integration_test -- -D warnings` passes; `cargo test -p hyperlane-midnight` passes (10 tests).