### PR TITLE
chore: bump Rust toolchain to 1.89 for Midnight decode crates

### DIFF
--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -629,16 +629,23 @@ impl PendingMessage {
         origin_db: Arc<dyn HyperlaneDb>,
         message: &HyperlaneMessage,
     ) -> PendingOperationStatus {
+        // Level for the db-status trace events: DEBUG under test-utils (so
+        // E2E tests can assert on the log) and TRACE otherwise. Defined as a
+        // cfg-selected const rather than an inline `if cfg!(...)` inside the
+        // event! macro: the inline conditional creates a temporary that fails
+        // to compile on rustc >= 1.89 (E0716 "temporary value dropped while
+        // borrowed"). This const form compiles on 1.88 and 1.89 alike.
+        #[cfg(feature = "test-utils")]
+        const DB_STATUS_LEVEL: Level = Level::DEBUG;
+        #[cfg(not(feature = "test-utils"))]
+        const DB_STATUS_LEVEL: Level = Level::TRACE;
+
         // Attempt to fetch status about message from database
         if let Ok(Some(status)) = origin_db.retrieve_status_by_message_id(&message.id()) {
             // This event is used for E2E tests to ensure message statuses
             // are being properly loaded from the db
             tracing::event!(
-                if cfg!(feature = "test-utils") {
-                    Level::DEBUG
-                } else {
-                    Level::TRACE
-                },
+                DB_STATUS_LEVEL,
                 ?status,
                 id=?message.id(),
                 RETRIEVED_MESSAGE_LOG,
@@ -646,14 +653,7 @@ impl PendingMessage {
             return status;
         }
 
-        tracing::event!(
-            if cfg!(feature = "test-utils") {
-                Level::DEBUG
-            } else {
-                Level::TRACE
-            },
-            "Message status not found in db"
-        );
+        tracing::event!(DB_STATUS_LEVEL, "Message status not found in db");
         PendingOperationStatus::FirstPrepareAttempt
     }
 

--- a/rust/main/rust-toolchain
+++ b/rust/main/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 profile = "default"


### PR DESCRIPTION
## Why

The native contract-state decode added for #14 depends on Midnight's ledger crates (`midnight-onchain-runtime` / `midnight-serialize` / `midnight-storage-core`), which transitively require `konst 0.4.3`. `konst 0.4.3`'s MSRV is **rustc 1.89** (it relies on 1.89 const-string-pattern behaviour; it's also edition 2024). The fork pins 1.88, so the Midnight decode can't compile without this bump.

Upstream `hyperlane-xyz` is still on 1.88 (checked 2026-06-22) and isn't moving yet, so this bump is **fork-only**.

## What

Two split commits:

- **`fix(relayer): cfg-select trace level instead of inline conditional`** — `tracing::event!(if cfg!(feature="test-utils") { Level::DEBUG } else { Level::TRACE }, ...)` creates a temporary that fails to compile on rustc >= 1.89 (`E0716`, temporary value dropped while borrowed). Replaced the inline conditional with a cfg-selected `const` used at both call sites. **Compiles on 1.88 and 1.89 alike, no behaviour change** — so this commit is upstreamable on its own (cherry-pick to a `hyperlane-xyz` PR).
- **`chore: bump Rust toolchain 1.88 -> 1.89`** — bumps `rust/main/rust-toolchain`.

## Verification

`cargo check -p relayer` builds clean under 1.89 (including the Midnight ZK dep graph). The only hard 1.89 incompatibility in the workspace was the single `tracing::event!` site fixed here. Two further future-incompat **warnings** remain (non-blocking): `hyperlane-base/src/settings/chains.rs:1566` and `hyperlane-ethereum/src/rpc_clients/provider.rs:351`.
