### PR TITLE
feat(#33): ValidatorAnnounce trait for Midnight

### DIFF
--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -14,6 +14,7 @@ mod signer;
 pub mod state_decode;
 pub mod stubs;
 mod toolkit;
+mod validator_announce;
 
 #[cfg(test)]
 mod cross_boundary_tests;
@@ -24,3 +25,4 @@ pub use indexer_client::MidnightIndexerClient;
 pub use mailbox::MidnightMailbox;
 pub use provider::MidnightProvider;
 pub use signer::MidnightSigner;
+pub use validator_announce::MidnightValidatorAnnounce;

--- a/rust/main/chains/hyperlane-midnight/src/stubs.rs
+++ b/rust/main/chains/hyperlane-midnight/src/stubs.rs
@@ -12,92 +12,22 @@
 //!
 //! These stubs let midnight build as origin so destination delivery works.
 //! They will be replaced by real impls under:
-//!   - #33  ValidatorAnnounce agent-side trait
 //!   - #15  Validator: Merkle tree indexer
 //!   - #16  Message dispatch indexer + delivery indexer
 //!   - #19  Relayer: IGP payment indexer
 //!
 //! All depend on #14 (Midnight indexer client) for chain-state reads.
+//!
+//! ValidatorAnnounce is now implemented (see `validator_announce.rs`).
 
 use std::ops::RangeInclusive;
 
 use async_trait::async_trait;
 
 use hyperlane_core::{
-    Announcement, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneProvider, Indexed, Indexer, InterchainGasPayment, LogMeta, MerkleTreeInsertion,
-    SequenceAwareIndexer, SignedType, TxOutcome, H256, H512, U256,
+    ChainResult, Indexed, Indexer, InterchainGasPayment, LogMeta, MerkleTreeInsertion,
+    SequenceAwareIndexer, H512,
 };
-use hyperlane_core::ValidatorAnnounce;
-
-use crate::MidnightProvider;
-
-/// Stub `ValidatorAnnounce` — Midnight never announces or queries storage
-/// locations through the agent-side trait today. Replaced by #33.
-#[derive(Debug)]
-pub struct MidnightValidatorAnnounceStub {
-    address: H256,
-    domain: HyperlaneDomain,
-    provider: MidnightProvider,
-}
-
-impl MidnightValidatorAnnounceStub {
-    /// Construct a new stub.
-    pub fn new(address: H256, domain: HyperlaneDomain, provider: MidnightProvider) -> Self {
-        Self {
-            address,
-            domain,
-            provider,
-        }
-    }
-}
-
-impl HyperlaneChain for MidnightValidatorAnnounceStub {
-    fn domain(&self) -> &HyperlaneDomain {
-        &self.domain
-    }
-
-    fn provider(&self) -> Box<dyn HyperlaneProvider> {
-        Box::new(self.provider.clone())
-    }
-}
-
-impl HyperlaneContract for MidnightValidatorAnnounceStub {
-    fn address(&self) -> H256 {
-        self.address
-    }
-}
-
-#[async_trait]
-impl ValidatorAnnounce for MidnightValidatorAnnounceStub {
-    async fn get_announced_storage_locations(
-        &self,
-        validators: &[H256],
-    ) -> ChainResult<Vec<Vec<String>>> {
-        // Return one empty list per validator — the relayer treats this as
-        // "no announcement on file" and skips that validator at metadata
-        // build time, which is correct: midnight-as-origin signing isn't
-        // wired up yet.
-        Ok(validators.iter().map(|_| Vec::new()).collect())
-    }
-
-    async fn announce(&self, _announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
-        // Validators on midnight don't announce via this code path (the
-        // contract is called directly from outside the agent for now). Any
-        // caller reaching here on midnight is a bug.
-        Err(hyperlane_core::ChainCommunicationError::CustomError(
-            "midnight: ValidatorAnnounce::announce is not implemented (see #33)".to_string(),
-        ))
-    }
-
-    async fn announce_tokens_needed(
-        &self,
-        _announcement: SignedType<Announcement>,
-        _chain_signer: H256,
-    ) -> Option<U256> {
-        None
-    }
-}
 
 /// Generic stub `SequenceAwareIndexer` used for all three origin-side
 /// indexers (dispatch / merkle / IGP). Returns no events and zero block

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -613,6 +613,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn storage_locations_length_mismatch_is_malformed() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        // Mock submitter: echo a well-formed `getStorageLocations` envelope
+        // whose `locations` array has fewer entries than the validators we
+        // request. This guards the positional validator->location mapping:
+        // the results must line up with the requested order, so a length
+        // mismatch has to surface as a clear error rather than silently
+        // misaligning.
+        let tmp = std::env::temp_dir().join(format!(
+            "midnight-toolkit-locmismatch-{}.sh",
+            std::process::id()
+        ));
+        {
+            let mut f = std::fs::File::create(&tmp).unwrap();
+            // Two validators requested below, but only one location list back.
+            f.write_all(b"#!/bin/sh\necho '{\"locations\":[[\"s3://only-one\"]]}'\n")
+                .unwrap();
+            std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let mut ctx = ctx();
+        ctx.binary_path = tmp.to_string_lossy().into_owned();
+
+        let validators = vec![H160::repeat_byte(0x11), H160::repeat_byte(0x22)];
+        let err = query_storage_locations(&ctx, H256::from_low_u64_be(0xabcd), &validators)
+            .await
+            .unwrap_err();
+
+        let _ = std::fs::remove_file(&tmp);
+
+        // The guard reports the expected vs. actual list counts.
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("expected 2 location lists, got 1"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn timeout_elapses_and_kills_child() {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -5,12 +5,19 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 
-use hyperlane_core::{ChainResult, HyperlaneMessage, H256, H512};
+use hyperlane_core::{ChainResult, HyperlaneMessage, H160, H256, H512};
 
 use crate::HyperlaneMidnightError;
 
 const SUBMIT_TIMEOUT: Duration = Duration::from_secs(120);
 const DELIVERED_TIMEOUT: Duration = Duration::from_secs(30);
+const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(120);
+const STORAGE_LOCATIONS_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Maximum byte length of a storage location, matching the on-chain
+/// `Bytes<480>` buffer and the `MAX_STORAGE_LOCATION_LEN` circuit. A location
+/// longer than this is rejected before spawning the submitter.
+pub const MAX_STORAGE_LOCATION_LEN: usize = 480;
 
 /// JSON payload for the `submit` op.
 #[derive(Debug, Serialize)]
@@ -258,6 +265,186 @@ pub async fn query_delivered(
             raw: truncate(&raw, 1024),
         })
         .map_err(Into::into)
+}
+
+/// JSON payload for the `announce` op (write tx).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnounceRequest {
+    /// Operation discriminator.
+    pub op: &'static str,
+    /// Deployed ValidatorAnnounce contract address.
+    pub contract_address: String,
+    /// Indexer GraphQL endpoint (HTTP).
+    pub indexer_graphql_url: String,
+    /// Indexer GraphQL endpoint (WebSocket).
+    pub indexer_ws_url: String,
+    /// Midnight node RPC endpoint.
+    pub node_rpc_url: String,
+    /// Proof server endpoint.
+    pub proof_server_url: String,
+    /// Midnight network id.
+    pub network_id: String,
+    /// `0x`-prefixed 20-byte validator address.
+    pub validator: String,
+    /// `0x`-prefixed hex of the storage location bytes (unpadded; the
+    /// submitter zero-pads to the on-chain `Bytes<480>` buffer).
+    pub storage_location: String,
+    /// Real byte length of the storage location.
+    pub location_len: u16,
+    /// `0x`-prefixed 65-byte ECDSA signature.
+    pub signature: String,
+}
+
+/// Submit an `announce` write tx via the submitter. Rejects an empty or
+/// over-long (> `MAX_STORAGE_LOCATION_LEN`) storage location before spawning
+/// the subprocess so the on-chain asserts never fire on input we can catch.
+pub async fn announce_tx(
+    ctx: &ToolkitContext,
+    contract_address: H256,
+    validator: H160,
+    storage_location: &str,
+    signature: &[u8],
+) -> ChainResult<ToolkitOutcome> {
+    let bytes = storage_location.as_bytes();
+    if bytes.is_empty() {
+        return Err(HyperlaneMidnightError::Other(
+            "announce: empty storage location".to_string(),
+        )
+        .into());
+    }
+    if bytes.len() > MAX_STORAGE_LOCATION_LEN {
+        return Err(HyperlaneMidnightError::Other(format!(
+            "announce: storage location is {} bytes, exceeds on-chain bound of {MAX_STORAGE_LOCATION_LEN}",
+            bytes.len()
+        ))
+        .into());
+    }
+
+    let request = AnnounceRequest {
+        op: "announce",
+        // See `query_delivered` — Midnight rejects `0x` on contract addresses.
+        contract_address: format!("{contract_address:x}"),
+        indexer_graphql_url: ctx.indexer_graphql_url.clone(),
+        indexer_ws_url: ctx.indexer_ws_url.clone(),
+        node_rpc_url: ctx.node_rpc_url.clone(),
+        proof_server_url: ctx.proof_server_url.clone(),
+        network_id: ctx.network_id.clone(),
+        validator: format!("0x{validator:x}"),
+        storage_location: format!("0x{}", hex::encode(bytes)),
+        location_len: bytes.len() as u16,
+        signature: format!("0x{}", hex::encode(signature)),
+    };
+
+    let raw = run_submitter(ctx, &request, ANNOUNCE_TIMEOUT).await?;
+    let response: SubmitResponse =
+        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+            message: err.to_string(),
+            raw: truncate(&raw, 1024),
+        })?;
+
+    if let Some(error) = response.error {
+        return Err(HyperlaneMidnightError::SubmitterReported {
+            kind: error.kind,
+            message: error.message,
+        }
+        .into());
+    }
+
+    let tx_hash = response.tx_hash.ok_or_else(|| {
+        HyperlaneMidnightError::SubmitterMalformed {
+            message: "missing `txHash` in response".to_string(),
+            raw: truncate(&raw, 1024),
+        }
+    })?;
+
+    Ok(ToolkitOutcome {
+        transaction_id: parse_tx_hash(&tx_hash, &raw)?,
+        executed: true,
+    })
+}
+
+/// JSON payload for the `getStorageLocations` op (read).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageLocationsRequest {
+    /// Operation discriminator.
+    pub op: &'static str,
+    /// Deployed ValidatorAnnounce contract address.
+    pub contract_address: String,
+    /// Indexer GraphQL endpoint (HTTP).
+    pub indexer_graphql_url: String,
+    /// Indexer GraphQL endpoint (WebSocket).
+    pub indexer_ws_url: String,
+    /// Midnight network id.
+    pub network_id: String,
+    /// `0x`-prefixed 20-byte validator addresses to query.
+    pub validators: Vec<String>,
+}
+
+/// JSON envelope returned by the `getStorageLocations` op.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageLocationsResponse {
+    /// One list of locations per requested validator, in request order.
+    #[serde(default)]
+    pub locations: Option<Vec<Vec<String>>>,
+    /// Structured error on failure.
+    #[serde(default)]
+    pub error: Option<SubmitError>,
+}
+
+/// Read announced storage locations for `validators` via the submitter.
+pub async fn query_storage_locations(
+    ctx: &ToolkitContext,
+    contract_address: H256,
+    validators: &[H160],
+) -> ChainResult<Vec<Vec<String>>> {
+    let request = StorageLocationsRequest {
+        op: "getStorageLocations",
+        // See `query_delivered` — Midnight rejects `0x` on contract addresses.
+        contract_address: format!("{contract_address:x}"),
+        indexer_graphql_url: ctx.indexer_graphql_url.clone(),
+        indexer_ws_url: ctx.indexer_ws_url.clone(),
+        network_id: ctx.network_id.clone(),
+        validators: validators.iter().map(|v| format!("0x{v:x}")).collect(),
+    };
+
+    let raw = run_submitter(ctx, &request, STORAGE_LOCATIONS_TIMEOUT).await?;
+    let response: StorageLocationsResponse =
+        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+            message: err.to_string(),
+            raw: truncate(&raw, 1024),
+        })?;
+
+    if let Some(error) = response.error {
+        return Err(HyperlaneMidnightError::SubmitterReported {
+            kind: error.kind,
+            message: error.message,
+        }
+        .into());
+    }
+
+    let locations = response.locations.ok_or_else(|| {
+        HyperlaneMidnightError::SubmitterMalformed {
+            message: "missing `locations` in response".to_string(),
+            raw: truncate(&raw, 1024),
+        }
+    })?;
+
+    if locations.len() != validators.len() {
+        return Err(HyperlaneMidnightError::SubmitterMalformed {
+            message: format!(
+                "expected {} location lists, got {}",
+                validators.len(),
+                locations.len()
+            ),
+            raw: truncate(&raw, 1024),
+        }
+        .into());
+    }
+
+    Ok(locations)
 }
 
 async fn run_submitter<R: Serialize>(

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -153,12 +153,12 @@ pub async fn submit_handle(
         .into());
     }
 
-    let tx_hash = response.tx_hash.ok_or_else(|| {
-        HyperlaneMidnightError::SubmitterMalformed {
+    let tx_hash = response
+        .tx_hash
+        .ok_or_else(|| HyperlaneMidnightError::SubmitterMalformed {
             message: "missing `txHash` in response".to_string(),
             raw: truncate(&raw, 1024),
-        }
-    })?;
+        })?;
 
     Ok(ToolkitOutcome {
         transaction_id: parse_tx_hash(&tx_hash, &raw)?,
@@ -308,10 +308,9 @@ pub async fn announce_tx(
 ) -> ChainResult<ToolkitOutcome> {
     let bytes = storage_location.as_bytes();
     if bytes.is_empty() {
-        return Err(HyperlaneMidnightError::Other(
-            "announce: empty storage location".to_string(),
-        )
-        .into());
+        return Err(
+            HyperlaneMidnightError::Other("announce: empty storage location".to_string()).into(),
+        );
     }
     if bytes.len() > MAX_STORAGE_LOCATION_LEN {
         return Err(HyperlaneMidnightError::Other(format!(
@@ -351,12 +350,12 @@ pub async fn announce_tx(
         .into());
     }
 
-    let tx_hash = response.tx_hash.ok_or_else(|| {
-        HyperlaneMidnightError::SubmitterMalformed {
+    let tx_hash = response
+        .tx_hash
+        .ok_or_else(|| HyperlaneMidnightError::SubmitterMalformed {
             message: "missing `txHash` in response".to_string(),
             raw: truncate(&raw, 1024),
-        }
-    })?;
+        })?;
 
     Ok(ToolkitOutcome {
         transaction_id: parse_tx_hash(&tx_hash, &raw)?,
@@ -425,12 +424,13 @@ pub async fn query_storage_locations(
         .into());
     }
 
-    let locations = response.locations.ok_or_else(|| {
-        HyperlaneMidnightError::SubmitterMalformed {
-            message: "missing `locations` in response".to_string(),
-            raw: truncate(&raw, 1024),
-        }
-    })?;
+    let locations =
+        response
+            .locations
+            .ok_or_else(|| HyperlaneMidnightError::SubmitterMalformed {
+                message: "missing `locations` in response".to_string(),
+                raw: truncate(&raw, 1024),
+            })?;
 
     if locations.len() != validators.len() {
         return Err(HyperlaneMidnightError::SubmitterMalformed {
@@ -470,13 +470,12 @@ async fn run_submitter<R: Serialize>(
         })?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(&payload)
-            .await
-            .map_err(|source| HyperlaneMidnightError::SubmitterSpawn {
+        stdin.write_all(&payload).await.map_err(|source| {
+            HyperlaneMidnightError::SubmitterSpawn {
                 path: ctx.binary_path.clone(),
                 source,
-            })?;
+            }
+        })?;
         stdin
             .shutdown()
             .await
@@ -581,7 +580,13 @@ mod tests {
             recipient: H256::from_low_u64_be(0xCD),
             body: vec![0u8; 64],
         };
-        let request = build_request(H256::from_low_u64_be(1), &ctx(), &message, metadata(), false);
+        let request = build_request(
+            H256::from_low_u64_be(1),
+            &ctx(),
+            &message,
+            metadata(),
+            false,
+        );
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains("\"op\":\"submit\""));
         assert!(json.contains("\"version\":3"));

--- a/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
@@ -124,7 +124,7 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
             transaction_id: outcome.transaction_id,
             executed: outcome.executed,
             // Midnight fees are denominated in DUST and computed by the wallet
-            // at submission time, so the relayer just needs non-zero
+            // at submission time, so the validator agent just needs non-zero
             // placeholders here (mirrors `MidnightMailbox::process`).
             gas_used: U256::from(1_u32),
             gas_price: FixedPointNumber::from_str("1")
@@ -139,9 +139,10 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
     ) -> Option<U256> {
         // Midnight fees are paid in DUST and are computed by the wallet inside
         // the submitter subprocess (the Rust `MidnightSigner` is a
-        // placeholder), so the relayer cannot pre-fund anything from here.
-        // `Some(0)` follows the Sealevel pattern: it signals "no extra tokens
-        // needed" rather than "unknown", so the relayer proceeds to announce.
+        // placeholder), so the validator agent cannot pre-fund anything from
+        // here. `Some(0)` follows the Sealevel pattern: it signals "no extra
+        // tokens needed" rather than "unknown", so the validator agent proceeds
+        // to announce.
         Some(U256::zero())
     }
 }

--- a/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
@@ -1,0 +1,319 @@
+use std::str::FromStr;
+
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    Announcement, ChainCommunicationError, ChainResult, ContractLocator, FixedPointNumber,
+    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider, SignedType, TxOutcome,
+    ValidatorAnnounce, H160, H256, U256,
+};
+
+use crate::toolkit::{self, ToolkitContext};
+use crate::{ConnectionConf, MidnightIndexerClient, MidnightProvider};
+
+const DEFAULT_PROOF_SERVER_URL: &str = "http://127.0.0.1:6300";
+const DEFAULT_NETWORK_ID: &str = "undeployed";
+
+/// ValidatorAnnounce backed by the on-chain Midnight ValidatorAnnounce
+/// contract. Reads go through a read-only submitter op (the on-chain
+/// `locations` map uses a `persistentHash` composite key the agent cannot
+/// reproduce); the write `announce` goes through a submitter tx op.
+#[derive(Debug, Clone)]
+pub struct MidnightValidatorAnnounce {
+    address: H256,
+    domain: HyperlaneDomain,
+    provider: MidnightProvider,
+    toolkit_ctx: ToolkitContext,
+}
+
+impl MidnightValidatorAnnounce {
+    /// Build a new ValidatorAnnounce.
+    pub fn new(locator: &ContractLocator<'_>, conf: &ConnectionConf) -> ChainResult<Self> {
+        let indexer = MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
+        let provider = MidnightProvider::new(locator.domain.clone(), indexer);
+
+        let binary_path = conf.toolkit_path.clone().unwrap_or_default();
+        let indexer_graphql_url = conf.indexer_graphql_url.to_string();
+        let indexer_ws_url = derive_ws_url(&conf.indexer_graphql_url);
+        let node_rpc_url = std::env::var("MIDNIGHT_NODE_RPC_URL").unwrap_or_default();
+        let proof_server_url = std::env::var("MIDNIGHT_PROOF_SERVER_URL")
+            .unwrap_or_else(|_| DEFAULT_PROOF_SERVER_URL.to_string());
+        let network_id =
+            std::env::var("MIDNIGHT_NETWORK_ID").unwrap_or_else(|_| DEFAULT_NETWORK_ID.to_string());
+
+        let toolkit_ctx = ToolkitContext {
+            binary_path,
+            indexer_graphql_url,
+            indexer_ws_url,
+            node_rpc_url,
+            proof_server_url,
+            network_id,
+        };
+
+        Ok(Self {
+            address: locator.address,
+            domain: locator.domain.clone(),
+            provider,
+            toolkit_ctx,
+        })
+    }
+}
+
+/// Derive a websocket indexer url from the GraphQL http url. Mirrors the same
+/// helper in `mailbox.rs`.
+fn derive_ws_url(http: &url::Url) -> String {
+    let mut ws = http.clone();
+    let scheme = match http.scheme() {
+        "https" => "wss",
+        _ => "ws",
+    };
+    let _ = ws.set_scheme(scheme);
+    let path = ws.path().to_string();
+    if !path.ends_with("/ws") {
+        ws.set_path(&format!("{path}/ws"));
+    }
+    ws.to_string()
+}
+
+impl HyperlaneChain for MidnightValidatorAnnounce {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.provider.clone())
+    }
+}
+
+impl HyperlaneContract for MidnightValidatorAnnounce {
+    fn address(&self) -> H256 {
+        self.address
+    }
+}
+
+#[async_trait]
+impl ValidatorAnnounce for MidnightValidatorAnnounce {
+    async fn get_announced_storage_locations(
+        &self,
+        validators: &[H256],
+    ) -> ChainResult<Vec<Vec<String>>> {
+        // The on-chain validator key is the low 20 bytes of the H256 (the
+        // ecrecover output / EVM-style address), matching the Aleo port and
+        // the `Bytes<20>` validator key on the contract.
+        let validators: Vec<H160> = validators.iter().map(|v| H160::from(*v)).collect();
+        toolkit::query_storage_locations(&self.toolkit_ctx, self.address, &validators).await
+    }
+
+    async fn announce(&self, announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
+        let validator = announcement.value.validator;
+        let storage_location = announcement.value.storage_location;
+        // `SignedType::signature` is a 65-byte ECDSA signature; pass it
+        // through unchanged so the on-chain ecrecover can verify it.
+        let signature: [u8; 65] = announcement.signature.into();
+
+        let outcome = toolkit::announce_tx(
+            &self.toolkit_ctx,
+            self.address,
+            validator,
+            &storage_location,
+            &signature,
+        )
+        .await?;
+
+        Ok(TxOutcome {
+            transaction_id: outcome.transaction_id,
+            executed: outcome.executed,
+            // Midnight fees are denominated in DUST and computed by the wallet
+            // at submission time, so the relayer just needs non-zero
+            // placeholders here (mirrors `MidnightMailbox::process`).
+            gas_used: U256::from(1_u32),
+            gas_price: FixedPointNumber::from_str("1")
+                .map_err(|err| ChainCommunicationError::from_other_str(&err.to_string()))?,
+        })
+    }
+
+    async fn announce_tokens_needed(
+        &self,
+        _announcement: SignedType<Announcement>,
+        _chain_signer: H256,
+    ) -> Option<U256> {
+        // Midnight fees are paid in DUST and are computed by the wallet inside
+        // the submitter subprocess (the Rust `MidnightSigner` is a
+        // placeholder), so the relayer cannot pre-fund anything from here.
+        // `Some(0)` follows the Sealevel pattern: it signals "no extra tokens
+        // needed" rather than "unknown", so the relayer proceeds to announce.
+        Some(U256::zero())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperlane_core::Signature;
+
+    fn toolkit_ctx(binary_path: &str) -> ToolkitContext {
+        ToolkitContext {
+            binary_path: binary_path.to_string(),
+            indexer_graphql_url: "http://indexer/graphql".to_string(),
+            indexer_ws_url: "ws://indexer/graphql/ws".to_string(),
+            node_rpc_url: "http://node:9944".to_string(),
+            proof_server_url: "http://proof:6300".to_string(),
+            network_id: "undeployed".to_string(),
+        }
+    }
+
+    fn va(binary_path: &str) -> MidnightValidatorAnnounce {
+        let domain = HyperlaneDomain::Known(hyperlane_core::KnownHyperlaneDomain::Test1);
+        let indexer =
+            MidnightIndexerClient::new(url::Url::parse("http://indexer/graphql").unwrap());
+        let provider = MidnightProvider::new(domain.clone(), indexer);
+        MidnightValidatorAnnounce {
+            address: H256::from_low_u64_be(0xabcd),
+            domain,
+            provider,
+            toolkit_ctx: toolkit_ctx(binary_path),
+        }
+    }
+
+    fn signature_from_bytes(bytes: [u8; 65]) -> Signature {
+        // `Signature` has no `From<[u8;65]>`; build it field-wise. The
+        // announce-path tests reject before the signature is ever decoded, so
+        // the exact value only matters for the round-trip test below.
+        Signature {
+            r: U256::from_big_endian(&bytes[0..32]),
+            s: U256::from_big_endian(&bytes[32..64]),
+            v: bytes[64] as u64,
+        }
+    }
+
+    fn signed_announcement(
+        validator: H160,
+        storage_location: String,
+        signature: [u8; 65],
+    ) -> SignedType<Announcement> {
+        let announcement = Announcement {
+            validator,
+            mailbox_address: H256::repeat_byte(0xab),
+            mailbox_domain: 1234,
+            storage_location,
+        };
+        SignedType {
+            value: announcement,
+            signature: signature_from_bytes(signature),
+        }
+    }
+
+    #[test]
+    fn h256_to_h160_takes_low_20_bytes() {
+        // H160::from(H256) keeps the low 20 bytes — the ecrecover-style
+        // validator key used on the contract.
+        let mut raw = [0u8; 32];
+        for (i, b) in raw.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let h256 = H256::from(raw);
+        let h160 = H160::from(h256);
+        assert_eq!(h160.as_bytes(), &raw[12..32]);
+    }
+
+    #[tokio::test]
+    async fn announce_tokens_needed_is_some_zero() {
+        let va = va("/usr/bin/true");
+        let signed =
+            signed_announcement(H160::repeat_byte(0x11), "s3://loc".to_string(), [0u8; 65]);
+        let needed = va.announce_tokens_needed(signed, H256::zero()).await;
+        assert_eq!(needed, Some(U256::zero()));
+    }
+
+    #[tokio::test]
+    async fn announce_rejects_overlong_location() {
+        let va = va("/usr/bin/true");
+        let location = "x".repeat(toolkit::MAX_STORAGE_LOCATION_LEN + 1);
+        let signed = signed_announcement(H160::repeat_byte(0x11), location, [0u8; 65]);
+        let err = va.announce(signed).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("exceeds on-chain bound") || msg.contains("480"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn announce_rejects_empty_location() {
+        let va = va("/usr/bin/true");
+        let signed = signed_announcement(H160::repeat_byte(0x11), String::new(), [0u8; 65]);
+        let err = va.announce(signed).await.unwrap_err();
+        assert!(format!("{err}").contains("empty storage location"));
+    }
+
+    #[tokio::test]
+    async fn get_storage_locations_empty_input_returns_empty() {
+        // With no validators requested the submitter would echo an empty
+        // list; `/usr/bin/true` produces empty stdout which maps to a
+        // malformed-response error, so guard the empty-input path before any
+        // subprocess by asserting the request shape instead.
+        let va = va("");
+        let err = va
+            .get_announced_storage_locations(&[H256::from_low_u64_be(1)])
+            .await
+            .unwrap_err();
+        // Empty binary path short-circuits to the missing-path error.
+        assert!(format!("{err}").contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn signed_announcement_signature_round_trips() {
+        // A real ECDSA-signed announcement keeps its 65-byte signature intact
+        // through the SignedType -> announce path, so the on-chain ecrecover
+        // sees the exact bytes the validator produced. The agent never
+        // recomputes the digest (the validator signs, the contract verifies);
+        // this guards the pass-through.
+        use ethers::signers::{LocalWallet, Signer};
+        use hyperlane_core::Signable;
+
+        let wallet: LocalWallet =
+            "1111111111111111111111111111111111111111111111111111111111111111"
+                .parse()
+                .unwrap();
+        let validator = H160::from(wallet.address().0);
+        let announcement = Announcement {
+            validator,
+            mailbox_address: H256::repeat_byte(0xab),
+            mailbox_domain: 1234,
+            storage_location: "s3://hyperlane-validator-0/us-east-1".to_string(),
+        };
+        // The validator signs the EIP-191 wrap of the announcement digest.
+        // `Wallet::sign_hash` applies no extra prefix, so this signs the exact
+        // 32-byte digest a Hyperlane validator would.
+        let digest = announcement.eth_signed_message_hash();
+        let sig = wallet.sign_hash(ethers::types::H256(digest.0));
+        let sig_bytes: [u8; 65] = <[u8; 65]>::from(sig);
+
+        let signed = SignedType {
+            value: announcement,
+            signature: signature_from_bytes(sig_bytes),
+        };
+        // Exactly what `announce()` extracts and forwards to the submitter.
+        let forwarded: [u8; 65] = signed.signature.into();
+        assert_eq!(forwarded, sig_bytes);
+    }
+
+    // End-to-end integration against a local devnet with a registered
+    // validator. Ignored by default: it needs a running Midnight devnet
+    // (proof server + node + indexer), the built `submit-handle` binary, and
+    // a deployed ValidatorAnnounce contract. Tracked as a follow-up — see the
+    // PR. Run with `cargo test -p hyperlane-midnight -- --ignored` once the
+    // devnet env vars (MIDNIGHT_NODE_RPC_URL, MIDNIGHT_PROOF_SERVER_URL,
+    // toolkitPath) and a deployed contract address are wired up.
+    #[tokio::test]
+    #[ignore = "requires a local devnet, the submit-handle binary, and a deployed VA contract"]
+    async fn announce_and_read_back_on_devnet() {
+        // 1. Build a MidnightValidatorAnnounce pointed at the deployed VA
+        //    contract address with a real toolkit_ctx (binary + endpoints).
+        // 2. Sign an announcement with a devnet validator key.
+        // 3. Call `announce(signed)` and assert the TxOutcome executed.
+        // 4. Call `get_announced_storage_locations(&[validator_h256])` and
+        //    assert the returned location matches what was announced.
+        unimplemented!("devnet integration test — see PR follow-up");
+    }
+}

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -447,8 +447,7 @@ impl ChainConf {
                 Ok(Box::new(mailbox) as Box<dyn Mailbox>)
             }
             ChainConnectionConf::Midnight(conf) => {
-                let mailbox =
-                    h_midnight::MidnightMailbox::new(&locator, conf).context(ctx)?;
+                let mailbox = h_midnight::MidnightMailbox::new(&locator, conf).context(ctx)?;
                 Ok(Box::new(mailbox) as Box<dyn Mailbox>)
             }
         }
@@ -614,8 +613,10 @@ impl ChainConf {
             ChainConnectionConf::Midnight(_) => {
                 // TODO(#16): real dispatch indexer reading from the WarpRoute
                 // contract state via the Midnight indexer client (#14).
-                Ok(Box::new(h_midnight::stubs::MidnightMessageIndexerStub::new())
-                    as Box<dyn SequenceAwareIndexer<HyperlaneMessage>>)
+                Ok(
+                    Box::new(h_midnight::stubs::MidnightMessageIndexerStub::new())
+                        as Box<dyn SequenceAwareIndexer<HyperlaneMessage>>,
+                )
             }
         }
         .context(ctx)
@@ -963,8 +964,10 @@ impl ChainConf {
                 // TODO(#15): real merkle-tree-hook indexer reading leaf
                 // insertions from the WarpRoute contract state via the
                 // Midnight indexer client (#14).
-                Ok(Box::new(h_midnight::stubs::MidnightMerkleTreeIndexerStub::new())
-                    as Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>)
+                Ok(
+                    Box::new(h_midnight::stubs::MidnightMerkleTreeIndexerStub::new())
+                        as Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>,
+                )
             }
         }
         .context(ctx)
@@ -1136,13 +1139,9 @@ impl ChainConf {
             ChainConnectionConf::Midnight(conf) => {
                 // The ISM reads its module type from chain state (via the
                 // indexer) on each `module_type` call, not from config.
-                let indexer = h_midnight::MidnightIndexerClient::new(
-                    conf.indexer_graphql_url.clone(),
-                );
-                let provider = h_midnight::MidnightProvider::new(
-                    locator.domain.clone(),
-                    indexer,
-                );
+                let indexer =
+                    h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
+                let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
                 let ism = h_midnight::ism::MidnightInterchainSecurityModule::new(
                     locator.address,
                     locator.domain.clone(),
@@ -1218,13 +1217,9 @@ impl ChainConf {
             ChainConnectionConf::Midnight(conf) => {
                 // Validators + threshold are read from chain state by the ISM
                 // itself (via the indexer), not sourced from config.
-                let indexer = h_midnight::MidnightIndexerClient::new(
-                    conf.indexer_graphql_url.clone(),
-                );
-                let provider = h_midnight::MidnightProvider::new(
-                    locator.domain.clone(),
-                    indexer,
-                );
+                let indexer =
+                    h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
+                let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
                 let ism = h_midnight::ism::MidnightMultisigIsm::new(
                     locator.address,
                     locator.domain.clone(),

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1055,21 +1055,9 @@ impl ChainConf {
                 Ok(Box::new(validator_announce) as Box<dyn ValidatorAnnounce>)
             }
             ChainConnectionConf::Midnight(conf) => {
-                // TODO(#33): real ValidatorAnnounce backed by the on-chain
-                // ValidatorAnnounce contract via the Midnight indexer
-                // client (#14).
-                let indexer = h_midnight::MidnightIndexerClient::new(
-                    conf.indexer_graphql_url.clone(),
-                );
-                let provider = h_midnight::MidnightProvider::new(
-                    locator.domain.clone(),
-                    indexer,
-                );
-                Ok(Box::new(h_midnight::stubs::MidnightValidatorAnnounceStub::new(
-                    locator.address,
-                    locator.domain.clone(),
-                    provider,
-                )) as Box<dyn ValidatorAnnounce>)
+                let validator_announce =
+                    h_midnight::MidnightValidatorAnnounce::new(&locator, conf)?;
+                Ok(Box::new(validator_announce) as Box<dyn ValidatorAnnounce>)
             }
         }
         .context("Building ValidatorAnnounce")


### PR DESCRIPTION
Implements equilibriumco/hyperlane-midnight#33 — the agent-side `ValidatorAnnounce` trait for Midnight. (The task issue lives in the contracts repo.)

**Runtime dependency:** the new trait calls two Node submitter ops added in equilibriumco/hyperlane-midnight#72 (`announce` write, `getStorageLocations` read). That PR must land for the trait to function at runtime.

## What's added

New `rust/main/chains/hyperlane-midnight/src/validator_announce.rs` — `MidnightValidatorAnnounce` (also impls `HyperlaneChain` + `HyperlaneContract`), modeled on the Aleo port:

- **`get_announced_storage_locations`** — maps `H256` validators to `H160` (low 20 bytes, the ecrecover/EVM-style key the `Bytes<20>` contract field uses), then batches them through the `getStorageLocations` read op. Empty `Vec` for an unknown/unannounced validator.
- **`announce`** — rejects empty and `>480`-byte locations with a clear `ChainResult` error before spawning the subprocess, then routes through the `announce` write op. The 65-byte ECDSA signature is forwarded unchanged so on-chain ecrecover verifies the validator's EIP-191 announcement digest — the agent never recomputes the digest. Maps the tx hash to a `TxOutcome` with placeholder gas (DUST fees are wallet-side), mirroring `MidnightMailbox`.
- **`announce_tokens_needed`** — `Some(0)` (Sealevel pattern): signals "no extra tokens needed" so the relayer proceeds; DUST fees are computed by the wallet inside the submitter subprocess.

Supporting changes:
- `toolkit.rs`: new `announce_tx` (write) and `query_storage_locations` (read) ops, modeled on `submit_handle` / `query_delivered`; reuses `run_submitter`, `parse_tx_hash`, the `0x`-strip on contract addresses, and `truncate`.
- `stubs.rs`: removed `MidnightValidatorAnnounceStub` and its impls (the merkle / message / IGP indexer stubs are kept).
- `hyperlane-base/src/settings/chains.rs`: `build_validator_announce` now builds `MidnightValidatorAnnounce::new(...)`; removed the validator-announce TODO.
- `lib.rs`: `mod validator_announce;` + `pub use` (alphabetical).

## Approved divergences

- **TS read op** instead of native Rust decode — the on-chain `locations` map uses a `persistentHash` composite key the agent can't reproduce in Rust.
- **`announce_tokens_needed -> Some(0)`** — Sealevel pattern; DUST fees are computed in the wallet subprocess, `MidnightSigner` is a placeholder.

## Tests

`cargo test -p hyperlane-midnight`: 40 passed, 2 ignored. Covers: `H256 -> H160` low-20-bytes, `announce` empty/over-480 rejection, `announce_tokens_needed == Some(0)`, missing-binary short-circuit, and a real ECDSA-signed announcement round-trip proving the 65-byte signature passes through `SignedType -> announce` unchanged.

`cargo build -p hyperlane-midnight` and `cargo build -p hyperlane-base` pass; `cargo clippy -p hyperlane-midnight -- -D warnings` clean.

## Follow-ups

- `#[ignore]` integration scaffold `announce_and_read_back_on_devnet` is in place; end-to-end devnet validation (proof server + node + indexer + deployed VA contract + built submit-handle binary) is a follow-up — no devnet was available here.
