### PR TITLE
feat(#90): supply pubkey + pad location for real-crypto ValidatorAnnounce

### DIFF
--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -577,14 +577,23 @@ impl Validator {
     }
 
     fn announcement_location(&self) -> Result<String> {
+        use hyperlane_core::HyperlaneDomainProtocol;
         let location = self.checkpoint_syncer.announcement_location();
-        if self.origin_chain.domain_protocol() == hyperlane_core::HyperlaneDomainProtocol::Aleo {
-            Self::aleo_announcement_location(location)
-        } else {
-            Ok(location)
+        // Both Aleo and Midnight hash a fixed 480-byte padded location in their
+        // on-chain ValidatorAnnounce (their in-circuit keccak cannot hash a
+        // runtime-length prefix), so the validator must pad before signing. The
+        // padding shape is identical, hence the shared helper.
+        match self.origin_chain.domain_protocol() {
+            HyperlaneDomainProtocol::Aleo | HyperlaneDomainProtocol::Midnight => {
+                Self::aleo_announcement_location(location)
+            }
+            _ => Ok(location),
         }
     }
 
+    // Pad an announcement location to a fixed 480-byte C string (nulls fill the
+    // tail). Shared by Aleo and Midnight; the name is kept to avoid churn on the
+    // public fork.
     fn aleo_announcement_location(announcement_location: String) -> Result<String> {
         // Aleo announcement locations are fixed size C strings of 480 bytes (include nulls)
         let mut bytes = announcement_location.into_bytes();

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -577,23 +577,17 @@ impl Validator {
     }
 
     fn announcement_location(&self) -> Result<String> {
-        use hyperlane_core::HyperlaneDomainProtocol;
         let location = self.checkpoint_syncer.announcement_location();
-        // Both Aleo and Midnight hash a fixed 480-byte padded location in their
-        // on-chain ValidatorAnnounce (their in-circuit keccak cannot hash a
-        // runtime-length prefix), so the validator must pad before signing. The
-        // padding shape is identical, hence the shared helper.
-        match self.origin_chain.domain_protocol() {
-            HyperlaneDomainProtocol::Aleo | HyperlaneDomainProtocol::Midnight => {
-                Self::aleo_announcement_location(location)
-            }
-            _ => Ok(location),
+        let protocol = self.origin_chain.domain_protocol();
+        if protocol == hyperlane_core::HyperlaneDomainProtocol::Aleo
+            || protocol == hyperlane_core::HyperlaneDomainProtocol::Midnight
+        {
+            Self::aleo_announcement_location(location)
+        } else {
+            Ok(location)
         }
     }
 
-    // Pad an announcement location to a fixed 480-byte C string (nulls fill the
-    // tail). Shared by Aleo and Midnight; the name is kept to avoid churn on the
-    // public fork.
     fn aleo_announcement_location(announcement_location: String) -> Result<String> {
         // Aleo announcement locations are fixed size C strings of 480 bytes (include nulls)
         let mut bytes = announcement_location.into_bytes();

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -341,35 +341,57 @@ pub struct AnnounceRequest {
     pub network_id: String,
     /// `0x`-prefixed 20-byte validator address.
     pub validator: String,
-    /// `0x`-prefixed hex of the storage location bytes (unpadded; the
-    /// submitter zero-pads to the on-chain `Bytes<480>` buffer).
+    /// `0x`-prefixed hex of the FULL zero-padded `Bytes<480>` location buffer
+    /// — the exact bytes the validator signed over (#90). The submitter
+    /// forwards it verbatim; the on-chain digest hashes the padded buffer.
     pub storage_location: String,
-    /// Real byte length of the storage location.
-    pub location_len: u16,
-    /// `0x`-prefixed 65-byte ECDSA signature.
+    /// `0x`-prefixed 65-byte ECDSA signature (r || s || v).
     pub signature: String,
+    /// `0x`-prefixed 64-byte secp256k1 public-key body (X_be || Y_be, no 0x04
+    /// SEC1 tag), recovered off-chain from the signature. Midnight's Compact
+    /// has no in-circuit ecrecover, so the verify-based `announce` circuit
+    /// takes the pubkey and derives the validator address from it (#90).
+    pub pubkey: String,
 }
 
-/// Submit an `announce` write tx via the submitter. Rejects an empty or
-/// over-long (> `MAX_STORAGE_LOCATION_LEN`) storage location before spawning
-/// the subprocess so the on-chain asserts never fire on input we can catch.
+/// Submit an `announce` write tx via the submitter. Expects `storage_location`
+/// to be the padded `MAX_STORAGE_LOCATION_LEN`-byte buffer the validator signed
+/// over (the shared validator agent pads before signing, #90) with a trailing
+/// NUL, and `pubkey` to be the 64-byte body recovered off-chain. Validates both
+/// before spawning the subprocess so the on-chain asserts never fire on input
+/// we can catch.
 pub async fn announce_tx(
     ctx: &ToolkitContext,
     contract_address: H256,
     validator: H160,
     storage_location: &str,
     signature: &[u8],
+    pubkey: &[u8],
 ) -> ChainResult<ToolkitOutcome> {
     let bytes = storage_location.as_bytes();
-    if bytes.is_empty() {
+    if bytes.len() != MAX_STORAGE_LOCATION_LEN {
+        return Err(HyperlaneMidnightError::Other(format!(
+            "announce: storage location must be the padded {MAX_STORAGE_LOCATION_LEN}-byte buffer, got {} bytes",
+            bytes.len()
+        ))
+        .into());
+    }
+    if bytes[0] == 0 {
         return Err(
             HyperlaneMidnightError::Other("announce: empty storage location".to_string()).into(),
         );
     }
-    if bytes.len() > MAX_STORAGE_LOCATION_LEN {
+    // A trailing NUL must survive so off-chain readers can trim the padding.
+    if bytes[MAX_STORAGE_LOCATION_LEN - 1] != 0 {
+        return Err(HyperlaneMidnightError::Other(
+            "announce: storage location fills the padded buffer with no trailing NUL".to_string(),
+        )
+        .into());
+    }
+    if pubkey.len() != 64 {
         return Err(HyperlaneMidnightError::Other(format!(
-            "announce: storage location is {} bytes, exceeds on-chain bound of {MAX_STORAGE_LOCATION_LEN}",
-            bytes.len()
+            "announce: pubkey must be the 64-byte X_be||Y_be body, got {} bytes",
+            pubkey.len()
         ))
         .into());
     }
@@ -385,8 +407,8 @@ pub async fn announce_tx(
         network_id: ctx.network_id.clone(),
         validator: format!("0x{validator:x}"),
         storage_location: format!("0x{}", hex::encode(bytes)),
-        location_len: bytes.len() as u16,
         signature: format!("0x{}", hex::encode(signature)),
+        pubkey: format!("0x{}", hex::encode(pubkey)),
     };
 
     let raw = run_submitter(ctx, &request, ANNOUNCE_TIMEOUT).await?;
@@ -498,7 +520,22 @@ pub async fn query_storage_locations(
         .into());
     }
 
-    Ok(locations)
+    // Defence-in-depth: the on-chain buffer is zero-padded to 480 bytes and the
+    // TS read op already trims at the first NUL, but trim again here so a padded
+    // string can never leak through — the validator agent compares the returned
+    // location against its own UNPADDED `announcement_location()` and would
+    // re-announce forever on a mismatch.
+    let trimmed = locations
+        .into_iter()
+        .map(|per_validator| {
+            per_validator
+                .into_iter()
+                .map(|loc| loc.split('\0').next().unwrap_or("").to_string())
+                .collect()
+        })
+        .collect();
+
+    Ok(trimmed)
 }
 
 async fn run_submitter<R: Serialize>(

--- a/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 
 use hyperlane_core::{
     Announcement, ChainCommunicationError, ChainResult, ContractLocator, FixedPointNumber,
-    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider, SignedType, TxOutcome,
-    ValidatorAnnounce, H160, H256, U256,
+    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider, Signable, SignedType,
+    TxOutcome, ValidatorAnnounce, H160, H256, U256,
 };
 
 use crate::toolkit::{self, ToolkitContext};
@@ -75,6 +75,57 @@ fn derive_ws_url(http: &url::Url) -> String {
     ws.to_string()
 }
 
+/// Recover the signer's secp256k1 public key from a 65-byte Ethereum signature
+/// (`r || s || v`) over `digest`, returning the 64-byte SEC1 uncompressed body
+/// (`X_be || Y_be`, no `0x04` tag) — exactly what the on-chain `announce`
+/// circuit takes as its `pubkey` param (#90). k256 is reached via `ethers`
+/// (already a dependency; the same crate `state_decode.rs` uses to derive
+/// addresses from stored pubkeys).
+fn recover_pubkey_body(digest: H256, sig65: &[u8; 65]) -> ChainResult<[u8; 64]> {
+    use ethers::core::k256::ecdsa::{
+        recoverable::{Id as RecoveryId, Signature as RecoverableSignature},
+        Signature as K256Signature,
+    };
+    use ethers::core::k256::elliptic_curve::sec1::ToEncodedPoint;
+
+    let v = sig65[64];
+    // Hyperlane validators emit legacy {27, 28} recovery bytes; k256 wants {0, 1}.
+    let rec_byte = if v >= 27 { v - 27 } else { v };
+    let recovery_id = RecoveryId::new(rec_byte).map_err(|err| {
+        ChainCommunicationError::from_other_str(&format!("announce: invalid recovery id {v}: {err}"))
+    })?;
+    let sig = K256Signature::try_from(&sig65[..64]).map_err(|err| {
+        ChainCommunicationError::from_other_str(&format!("announce: malformed signature: {err}"))
+    })?;
+    let rsig = RecoverableSignature::new(&sig, recovery_id).map_err(|err| {
+        ChainCommunicationError::from_other_str(&format!(
+            "announce: bad recoverable signature: {err}"
+        ))
+    })?;
+    // `digest` is the already-hashed EIP-191 announcement digest (the prehash
+    // the validator signed over), so recover directly from these bytes.
+    let digest_bytes = digest.to_fixed_bytes();
+    let vk = rsig
+        .recover_verifying_key_from_digest_bytes(digest_bytes.as_ref().into())
+        .map_err(|err| {
+            ChainCommunicationError::from_other_str(&format!(
+                "announce: failed to recover pubkey: {err}"
+            ))
+        })?;
+    let point = vk.to_encoded_point(false);
+    let bytes = point.as_bytes();
+    // Uncompressed SEC1 is 65 bytes: 0x04 || X(32) || Y(32).
+    if bytes.len() != 65 {
+        return Err(ChainCommunicationError::from_other_str(&format!(
+            "announce: unexpected pubkey encoding length {}",
+            bytes.len()
+        )));
+    }
+    let mut body = [0u8; 64];
+    body.copy_from_slice(&bytes[1..65]);
+    Ok(body)
+}
+
 impl HyperlaneChain for MidnightValidatorAnnounce {
     fn domain(&self) -> &HyperlaneDomain {
         &self.domain
@@ -98,7 +149,7 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
         validators: &[H256],
     ) -> ChainResult<Vec<Vec<String>>> {
         // The on-chain validator key is the low 20 bytes of the H256 (the
-        // ecrecover output / EVM-style address), matching the Aleo port and
+        // EVM-style address the pubkey derives to), matching the Aleo port and
         // the `Bytes<20>` validator key on the contract.
         let validators: Vec<H160> = validators.iter().map(|v| H160::from(*v)).collect();
         toolkit::query_storage_locations(&self.toolkit_ctx, self.address, &validators).await
@@ -106,10 +157,18 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
 
     async fn announce(&self, announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
         let validator = announcement.value.validator;
-        let storage_location = announcement.value.storage_location;
-        // `SignedType::signature` is a 65-byte ECDSA signature; pass it
-        // through unchanged so the on-chain ecrecover can verify it.
+        // The validator agent has already padded this to the fixed 480-byte
+        // buffer for Midnight (`announcement_location`), which is what it signed
+        // over; forward it verbatim.
+        let storage_location = announcement.value.storage_location.clone();
+        // `SignedType::signature` is a 65-byte ECDSA signature (r || s || v).
         let signature: [u8; 65] = announcement.signature.into();
+        // Midnight's Compact has no in-circuit ecrecover, so the verify-based
+        // `announce` circuit takes the signer's public key and derives the
+        // validator address from it (#90). Recover the pubkey off-chain from the
+        // EIP-191 announcement digest the validator signed.
+        let digest = announcement.value.eth_signed_message_hash();
+        let pubkey = recover_pubkey_body(digest, &signature)?;
 
         let outcome = toolkit::announce_tx(
             &self.toolkit_ctx,
@@ -117,6 +176,7 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
             validator,
             &storage_location,
             &signature,
+            &pubkey,
         )
         .await?;
 
@@ -206,8 +266,8 @@ mod tests {
 
     #[test]
     fn h256_to_h160_takes_low_20_bytes() {
-        // H160::from(H256) keeps the low 20 bytes — the ecrecover-style
-        // validator key used on the contract.
+        // H160::from(H256) keeps the low 20 bytes — the EVM-style 20-byte
+        // validator address used on the contract.
         let mut raw = [0u8; 32];
         for (i, b) in raw.iter_mut().enumerate() {
             *b = i as u8;
@@ -226,25 +286,88 @@ mod tests {
         assert_eq!(needed, Some(U256::zero()));
     }
 
+    // A well-formed 65-byte signature over an arbitrary hash, so `announce`'s
+    // off-chain pubkey recovery succeeds and the location/pubkey validation in
+    // `announce_tx` is what a test exercises. The value it signs is irrelevant
+    // — recovery yields *some* pubkey and the length checks fire before it is
+    // ever used on-chain.
+    fn valid_sig() -> [u8; 65] {
+        use ethers::signers::LocalWallet;
+        let wallet: LocalWallet =
+            "1111111111111111111111111111111111111111111111111111111111111111"
+                .parse()
+                .unwrap();
+        let sig = wallet.sign_hash(ethers::types::H256([0x42u8; 32]));
+        <[u8; 65]>::from(sig)
+    }
+
+    // Zero-pad a location into the fixed 480-byte buffer, as the validator agent
+    // does before signing.
+    fn padded(location: &str) -> String {
+        let mut bytes = location.as_bytes().to_vec();
+        bytes.resize(toolkit::MAX_STORAGE_LOCATION_LEN, 0);
+        String::from_utf8(bytes).unwrap()
+    }
+
     #[tokio::test]
-    async fn announce_rejects_overlong_location() {
+    async fn announce_rejects_non_480_location() {
+        // The fork expects the agent-padded 480-byte buffer; an unpadded
+        // location is rejected before the subprocess.
         let va = va("/usr/bin/true");
-        let location = "x".repeat(toolkit::MAX_STORAGE_LOCATION_LEN + 1);
-        let signed = signed_announcement(H160::repeat_byte(0x11), location, [0u8; 65]);
+        let signed = signed_announcement(H160::repeat_byte(0x11), "s3://loc".to_string(), valid_sig());
         let err = va.announce(signed).await.unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("exceeds on-chain bound") || msg.contains("480"),
+            msg.contains("padded") && msg.contains("480"),
             "unexpected error: {msg}"
         );
     }
 
     #[tokio::test]
-    async fn announce_rejects_empty_location() {
+    async fn announce_rejects_all_null_location() {
+        // A 480-byte buffer whose first byte is NUL is an empty location.
         let va = va("/usr/bin/true");
-        let signed = signed_announcement(H160::repeat_byte(0x11), String::new(), [0u8; 65]);
+        let signed = signed_announcement(H160::repeat_byte(0x11), padded(""), valid_sig());
         let err = va.announce(signed).await.unwrap_err();
         assert!(format!("{err}").contains("empty storage location"));
+    }
+
+    #[tokio::test]
+    async fn announce_rejects_location_with_no_trailing_nul() {
+        // 480 meaningful bytes leave no terminator, so trim-on-read would be
+        // ill-defined; rejected.
+        let va = va("/usr/bin/true");
+        let full = "x".repeat(toolkit::MAX_STORAGE_LOCATION_LEN);
+        let signed = signed_announcement(H160::repeat_byte(0x11), full, valid_sig());
+        let err = va.announce(signed).await.unwrap_err();
+        assert!(format!("{err}").contains("no trailing NUL"));
+    }
+
+    #[test]
+    fn recover_pubkey_body_derives_validator() {
+        // The off-chain recovery must reproduce the validator address the way
+        // the circuit will on-chain: keccak256(X_be || Y_be)[12..] == validator.
+        use ethers::signers::{LocalWallet, Signer};
+        use ethers::utils::keccak256;
+
+        let wallet: LocalWallet =
+            "2222222222222222222222222222222222222222222222222222222222222222"
+                .parse()
+                .unwrap();
+        let validator = H160::from(wallet.address().0);
+        let announcement = Announcement {
+            validator,
+            mailbox_address: H256::repeat_byte(0xab),
+            mailbox_domain: 1234,
+            storage_location: padded("s3://hyperlane-validator-0/us-east-1"),
+        };
+        let digest = announcement.eth_signed_message_hash();
+        let sig = wallet.sign_hash(ethers::types::H256(digest.0));
+        let sig_bytes = <[u8; 65]>::from(sig);
+
+        let pubkey = recover_pubkey_body(digest, &sig_bytes).unwrap();
+        let derived = &keccak256(pubkey)[12..];
+        assert_eq!(derived, validator.as_bytes());
     }
 
     #[tokio::test]
@@ -265,12 +388,11 @@ mod tests {
     #[tokio::test]
     async fn signed_announcement_signature_round_trips() {
         // A real ECDSA-signed announcement keeps its 65-byte signature intact
-        // through the SignedType -> announce path, so the on-chain ecrecover
-        // sees the exact bytes the validator produced. The agent never
-        // recomputes the digest (the validator signs, the contract verifies);
-        // this guards the pass-through.
+        // through the SignedType -> announce path, so the on-chain verify sees
+        // the exact bytes the validator produced. The agent never recomputes
+        // the digest (the validator signs, the contract verifies); this guards
+        // the pass-through.
         use ethers::signers::{LocalWallet, Signer};
-        use hyperlane_core::Signable;
 
         let wallet: LocalWallet =
             "1111111111111111111111111111111111111111111111111111111111111111"


### PR DESCRIPTION
Agent-side changes for the real-crypto Midnight ValidatorAnnounce (#90). The on-chain contract now hashes the announcement location padded to a fixed 480-byte buffer and verifies signatures against a supplied public key (Midnight's Compact has no in-circuit ecrecover). This wires the agents to match.

## Changes

- **validator agent** (`agents/validator/src/validator.rs`): extend the location-padding gate in `announcement_location` from `Aleo` to `Aleo | Midnight`. Both chains hash a fixed 480-byte C-string location on-chain (a fixed-arity in-circuit keccak cannot hash a runtime-length prefix), so the validator pads before signing. Shared `aleo_announcement_location` helper reused (name kept to avoid churn). The signed location is padded; the already-announced check still compares the unpadded location against the null-trimmed read-back.
- **`chains/hyperlane-midnight/src/validator_announce.rs`**: `announce` recovers the signer's secp256k1 public key off-chain from the EIP-191 announcement digest (k256 via `ethers`, the same crate `state_decode` uses to derive addresses from stored pubkeys) and forwards the 64-byte `X||Y` body to the submitter alongside the padded location and 65-byte signature.
- **`chains/hyperlane-midnight/src/toolkit.rs`**: `AnnounceRequest` drops `locationLen`, adds `pubkey`. `announce_tx` requires the padded 480-byte buffer with a trailing NUL and a 64-byte pubkey. `query_storage_locations` defensively trims returned locations at the first NUL so the validator's already-announced check matches.

## Tests

- `cargo test -p hyperlane-midnight`: 76 passed (incl. new `recover_pubkey_body_derives_validator` and the padded-buffer / pubkey validation cases).
- `cargo test -p validator --features midnight`: builds clean; 5 `announcement_location` padding tests pass.

Pairs with the contracts change in `equilibriumco/hyperlane-midnight#90`.
