### PR TITLE
fix(midnight-sdk): drop type assertions the current types no longer need

### DIFF
--- a/typescript/midnight-sdk/src/clients/read-client.ts
+++ b/typescript/midnight-sdk/src/clients/read-client.ts
@@ -57,7 +57,7 @@ export class MidnightReadClient {
         publicDataProvider,
         strip0x(contractAddress),
       );
-      return publicStates.contractState as unknown as FetchedContractState;
+      return publicStates.contractState;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (CONTRACT_NOT_FOUND_RE.test(message)) {

--- a/typescript/midnight-sdk/src/deploy/chunked-deploy.ts
+++ b/typescript/midnight-sdk/src/deploy/chunked-deploy.ts
@@ -321,8 +321,7 @@ export async function insertVerifierKeys(
   );
   const counter: bigint = contractState.maintenanceAuthority.counter;
   const unsigned = new ledger.MaintenanceUpdate(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    contractAddress as any,
+    contractAddress,
     updates,
     counter,
   );

--- a/typescript/midnight-sdk/src/deploy/providers.ts
+++ b/typescript/midnight-sdk/src/deploy/providers.ts
@@ -54,7 +54,7 @@ export async function createProviders(
       const recipe = await walletCtx.wallet.balanceUnboundTransaction(
         tx,
         {
-          shieldedSecretKeys: walletCtx.shieldedSecretKeys as any,
+          shieldedSecretKeys: walletCtx.shieldedSecretKeys,
           dustSecretKey: walletCtx.dustSecretKey,
         },
         { ttl: ttl ?? new Date(Date.now() + 30 * 60 * 1000) },
@@ -63,9 +63,8 @@ export async function createProviders(
       // `receiveUnshielded`-using circuit produces (e.g. `night.fund`).
       // Without it the chain rejects with
       // `MalformedError::InputsSignaturesLengthMismatch` (error 192).
-      const signed = await walletCtx.wallet.signRecipe(
-        recipe,
-        (payload) => walletCtx.unshieldedKeystore.signDataAsync(payload) as any,
+      const signed = await walletCtx.wallet.signRecipe(recipe, (payload) =>
+        walletCtx.unshieldedKeystore.signDataAsync(payload),
       );
       return walletCtx.wallet.finalizeRecipe(signed);
     },

--- a/typescript/midnight-sdk/src/ism/validators.test.ts
+++ b/typescript/midnight-sdk/src/ism/validators.test.ts
@@ -32,7 +32,7 @@ function multisigConfig(overrides: Partial<MultisigConfig>): MultisigConfig {
     threshold: 2,
     validatorPubkeys: PUBKEYS,
     ...overrides,
-  } as MultisigConfig;
+  };
 }
 
 describe('pubkeyToEthAddress', () => {


### PR DESCRIPTION
oxlint's no-unnecessary-type-assertion flags five casts in midnight-sdk that the current wallet SDK types make redundant. The per-commit hook only lints staged files, so these were never all in one commit and went unnoticed; they fail as soon as the package is linted as a whole.

Removing the MaintenanceUpdate cast also retires the eslint-disable that guarded it.